### PR TITLE
fix: stop candle close time (T) colliding with open time (t)

### DIFF
--- a/lib/hyperliquid/transport/http.ex
+++ b/lib/hyperliquid/transport/http.ex
@@ -1086,10 +1086,14 @@ defmodule Hyperliquid.Transport.Http do
   defp transform_keys(data), do: data
 
   defp to_snake_case(key) when is_binary(key) do
-    key
-    |> String.replace(~r/([A-Z])/, "_\\1")
-    |> String.downcase()
-    |> String.trim_leading("_")
+    if String.match?(key, ~r/^[A-Z]$/) do
+      key
+    else
+      key
+      |> String.replace(~r/([A-Z])/, "_\\1")
+      |> String.downcase()
+      |> String.trim_leading("_")
+    end
   end
 
   defp to_snake_case(key) when is_atom(key) do

--- a/test/api/info/candle_snapshot_test.exs
+++ b/test/api/info/candle_snapshot_test.exs
@@ -1,0 +1,40 @@
+defmodule Hyperliquid.Api.Info.CandleSnapshotTest do
+  use ExUnit.Case, async: false
+
+  alias Hyperliquid.Api.Info.CandleSnapshot
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:hyperliquid, :http_url, "http://localhost:#{bypass.port}")
+
+    {:ok, bypass: bypass}
+  end
+
+  test "keeps open time (t) and close time (T) as distinct values", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/info", fn conn ->
+      resp = [
+        %{
+          "t" => 1_785_153_600_000,
+          "T" => 1_785_157_199_999,
+          "s" => "LDO",
+          "i" => "1h",
+          "o" => "0.40148",
+          "c" => "0.40341",
+          "h" => "0.40447",
+          "l" => "0.3975",
+          "v" => "383090.9",
+          "n" => 920
+        }
+      ]
+
+      Plug.Conn.put_resp_header(conn, "content-type", "application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(resp))
+    end)
+
+    assert {:ok, %{candles: [candle]}} =
+             CandleSnapshot.request("LDO", "1h", 1_785_153_600_000, 1_785_157_200_000)
+
+    assert candle.t == 1_785_153_600_000
+    assert Map.get(candle, :T) == 1_785_157_199_999
+  end
+end


### PR DESCRIPTION
This was found by Claude whilst attempting to retrieve candles via the `Info.CandleSnapshot` module. What follows is LLM dross:

to_snake_case treated a lone uppercase letter as camelCase needing a word break, downcasing "T" to "t" and silently overwriting/losing the close timestamp on every CandleSnapshot and Candle subscription response. A single-letter key has no real word boundary, so leave it as-is instead of downcasing it into an unrelated sibling key.

...which kinda makes sense in a stream of (un)consciousness kinda way?