### PR TITLE
fix: make dex optional on the clearinghouseState subscription

### DIFF
--- a/lib/hyperliquid/api/subscription/clearinghouse_state.ex
+++ b/lib/hyperliquid/api/subscription/clearinghouse_state.ex
@@ -40,7 +40,7 @@ defmodule Hyperliquid.Api.Subscription.ClearinghouseState do
     changeset =
       {%{}, types}
       |> cast(params, Map.keys(types))
-      |> validate_required([:user, :dex])
+      |> validate_required([:user])
       |> validate_format(:user, ~r/^0x[0-9a-fA-F]{40}$/)
 
     if changeset.valid? do
@@ -48,7 +48,7 @@ defmodule Hyperliquid.Api.Subscription.ClearinghouseState do
        %{
          type: "clearinghouseState",
          user: get_change(changeset, :user),
-         dex: get_change(changeset, :dex)
+         dex: get_change(changeset, :dex) || ""
        }}
     else
       {:error, changeset}

--- a/test/api/subscription/clearinghouse_state_test.exs
+++ b/test/api/subscription/clearinghouse_state_test.exs
@@ -1,0 +1,31 @@
+defmodule Hyperliquid.Api.Subscription.ClearinghouseStateTest do
+  use ExUnit.Case, async: true
+
+  alias Hyperliquid.Api.Subscription.ClearinghouseState
+
+  test "builds a request for the main perps market when dex is omitted" do
+    assert {:ok, %{type: "clearinghouseState", user: "0x" <> _, dex: ""}} =
+             ClearinghouseState.build_request(%{user: "0x1234567890123456789012345678901234567890"})
+  end
+
+  test "builds a request for the main perps market when dex is the empty string" do
+    assert {:ok, %{dex: ""}} =
+             ClearinghouseState.build_request(%{
+               user: "0x1234567890123456789012345678901234567890",
+               dex: ""
+             })
+  end
+
+  test "builds a request for a named builder-deployed dex" do
+    assert {:ok, %{dex: "test"}} =
+             ClearinghouseState.build_request(%{
+               user: "0x1234567890123456789012345678901234567890",
+               dex: "test"
+             })
+  end
+
+  test "still requires a user" do
+    assert {:error, changeset} = ClearinghouseState.build_request(%{dex: ""})
+    assert {"can't be blank", [validation: :required]} = changeset.errors[:user]
+  end
+end


### PR DESCRIPTION
Another possible bug found by Claude. I want to automate a vault, which is on the first perp dex, which is "" according to the docs ([example](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals#request-body-1])). Slop:

validate_required treated dex as always missing whenever it was set to "", the documented default for the main perps market used everywhere else in the package (Info.ClearinghouseState, meta, metaAndAssetCtxs, perpDexStatus). That made it impossible to subscribe to the main market's clearinghouse state at all. dex is now optional, defaulting to "" like its Info sibling, while a named builder-deployed dex can still be passed explicitly.