### PR TITLE
fix(signing): align user-signed EIP-712 chainId with the reference SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.3.1
+
+### Changed
+
+- **User-signed actions now sign with `signatureChainId` `0x66eee` (421614).**
+  The EIP-712 domain's `chainId` and the action's `signatureChainId` must agree,
+  because the exchange rebuilds the domain from `signatureChainId` to recover the
+  signer. They did agree before, at `0xa4b1` (42161), so signatures verified —
+  but that diverged from the official Python SDK and the nktkas TypeScript SDK,
+  which both use `0x66eee`. Signatures are now byte-comparable with both.
+
+  Both values are accepted by the exchange; only self-consistency matters. The
+  Hyperliquid frontend itself sends `0xa4b1` (see
+  `test/debug/send_asset_debug_test.exs`, built from captured payloads). Set
+  `config :hyperliquid, signature_chain_id: 42_161` to restore the previous
+  behaviour.
+
+### Fixed
+
+- The `usdSend` EIP-712 test vector now passes. It had asserted the reference
+  SDKs' `0x66eee` signature while the library signed with `0xa4b1`.
+
+### Added
+
+- `Hyperliquid.Config.signature_chain_id/0` and `signature_chain_id_hex/0` — a
+  single source of truth for a value that was previously hardcoded in the Rust
+  NIF and in a dozen Elixir modules independently. That duplication is what
+  allowed the domain and `signatureChainId` to drift apart before `e0e67bf`.
+- `Hyperliquid.Api.Exchange.UserSigned` — shared EIP-712 domain and signing for
+  user-signed actions. The five actions that previously signed through
+  specialized Rust NIFs (`usdSend`, `withdraw3`, `spotSend`, `approveAgent`,
+  `approveBuilderFee`) now go through it, so configuration reaches them.
+  Verified byte-identical to the NIF path before switching.
+
+### Upgrade notes
+
+Precompiled NIFs are rebuilt for this release: the Rust `chain/1` default moved
+to 421614 so the standalone `Signer.sign_*` functions stay in step with
+`Config.signature_chain_id/0`.
+
 ## 0.3.0
 
 ### Fixed

--- a/lib/hyperliquid/api/exchange/approve_agent.ex
+++ b/lib/hyperliquid/api/exchange/approve_agent.ex
@@ -8,9 +8,17 @@ defmodule Hyperliquid.Api.Exchange.ApproveAgent do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
-  alias Hyperliquid.Api.Exchange.KeyUtils
+  alias Hyperliquid.{Config, Signer}
+  alias Hyperliquid.Api.Exchange.{KeyUtils, UserSigned}
   alias Hyperliquid.Transport.Http
+
+  @primary_type "HyperliquidTransaction:ApproveAgent"
+  @types [
+    %{name: "hyperliquidChain", type: "string"},
+    %{name: "agentAddress", type: "address"},
+    %{name: "agentName", type: "string"},
+    %{name: "nonce", type: "uint64"}
+  ]
 
   # ===================== Types =====================
 
@@ -80,7 +88,7 @@ defmodule Hyperliquid.Api.Exchange.ApproveAgent do
     action = %{
       type: "approveAgent",
       hyperliquidChain: if(is_mainnet, do: "Mainnet", else: "Testnet"),
-      signatureChainId: Utils.from_int(42_161),
+      signatureChainId: UserSigned.signature_chain_id(),
       agentAddress: agent_address,
       nonce: nonce
     }
@@ -95,15 +103,16 @@ defmodule Hyperliquid.Api.Exchange.ApproveAgent do
   # ===================== Signing =====================
 
   defp sign_approve(private_key, agent_address, agent_name, nonce) do
-    is_mainnet = Config.mainnet?()
+    message = %{
+      hyperliquidChain: UserSigned.hyperliquid_chain(),
+      agentAddress: agent_address,
+      # An unnamed agent signs over the empty string, which is also how the NIF
+      # decoded a nil name.
+      agentName: agent_name || "",
+      nonce: nonce
+    }
 
-    case Signer.sign_approve_agent(private_key, agent_address, agent_name, nonce, is_mainnet) do
-      %{"r" => r, "s" => s, "v" => v} ->
-        {:ok, %{r: r, s: s, v: v}}
-
-      error ->
-        {:error, {:signing_error, error}}
-    end
+    UserSigned.sign(private_key, @primary_type, @types, message)
   end
 
   defp generate_nonce do

--- a/lib/hyperliquid/api/exchange/approve_builder_fee.ex
+++ b/lib/hyperliquid/api/exchange/approve_builder_fee.ex
@@ -5,9 +5,17 @@ defmodule Hyperliquid.Api.Exchange.ApproveBuilderFee do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
-  alias Hyperliquid.Api.Exchange.KeyUtils
+  alias Hyperliquid.Config
+  alias Hyperliquid.Api.Exchange.{KeyUtils, UserSigned}
   alias Hyperliquid.Transport.Http
+
+  @primary_type "HyperliquidTransaction:ApproveBuilderFee"
+  @types [
+    %{name: "hyperliquidChain", type: "string"},
+    %{name: "maxFeeRate", type: "string"},
+    %{name: "builder", type: "address"},
+    %{name: "nonce", type: "uint64"}
+  ]
 
   @doc """
   Approve a builder to charge fees.
@@ -38,23 +46,28 @@ defmodule Hyperliquid.Api.Exchange.ApproveBuilderFee do
     nonce = generate_nonce()
     is_mainnet = Config.mainnet?()
 
-    sig = Signer.sign_approve_builder_fee(private_key, builder, max_fee_rate, nonce, is_mainnet)
+    hyperliquid_chain = if(is_mainnet, do: "Mainnet", else: "Testnet")
 
-    action = %{
-      type: "approveBuilderFee",
-      hyperliquidChain: if(is_mainnet, do: "Mainnet", else: "Testnet"),
-      signatureChainId: signature_chain_id(is_mainnet),
-      builder: builder,
+    message = %{
+      hyperliquidChain: hyperliquid_chain,
       maxFeeRate: max_fee_rate,
+      builder: builder,
       nonce: nonce
     }
 
-    signature = %{r: sig["r"], s: sig["s"], v: sig["v"]}
+    with {:ok, signature} <- UserSigned.sign(private_key, @primary_type, @types, message) do
+      action = %{
+        type: "approveBuilderFee",
+        hyperliquidChain: hyperliquid_chain,
+        signatureChainId: UserSigned.signature_chain_id(),
+        builder: builder,
+        maxFeeRate: max_fee_rate,
+        nonce: nonce
+      }
 
-    Http.user_signed_request(action, signature, nonce, opts)
+      Http.user_signed_request(action, signature, nonce, opts)
+    end
   end
-
-  defp signature_chain_id(_is_mainnet), do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/c_deposit.ex
+++ b/lib/hyperliquid/api/exchange/c_deposit.ex
@@ -5,7 +5,7 @@ defmodule Hyperliquid.Api.Exchange.CDeposit do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
+  alias Hyperliquid.{Config, Signer}
   alias Hyperliquid.Transport.Http
 
   @doc """
@@ -33,7 +33,7 @@ defmodule Hyperliquid.Api.Exchange.CDeposit do
     domain = %{
       name: "HyperliquidSignTransaction",
       version: "1",
-      chainId: 42_161,
+      chainId: Hyperliquid.Config.signature_chain_id(),
       verifyingContract: "0x0000000000000000000000000000000000000000"
     }
 
@@ -66,7 +66,7 @@ defmodule Hyperliquid.Api.Exchange.CDeposit do
       action = %{
         type: "cDeposit",
         hyperliquidChain: if(is_mainnet, do: "Mainnet", else: "Testnet"),
-        signatureChainId: signature_chain_id(is_mainnet),
+        signatureChainId: Hyperliquid.Config.signature_chain_id_hex(),
         wei: wei,
         nonce: nonce
       }
@@ -76,8 +76,6 @@ defmodule Hyperliquid.Api.Exchange.CDeposit do
       Http.user_signed_request(action, signature, nonce, opts)
     end
   end
-
-  defp signature_chain_id(_is_mainnet), do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/c_withdraw.ex
+++ b/lib/hyperliquid/api/exchange/c_withdraw.ex
@@ -5,7 +5,7 @@ defmodule Hyperliquid.Api.Exchange.CWithdraw do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
+  alias Hyperliquid.{Config, Signer}
   alias Hyperliquid.Transport.Http
 
   @doc """
@@ -32,7 +32,7 @@ defmodule Hyperliquid.Api.Exchange.CWithdraw do
     domain = %{
       name: "HyperliquidSignTransaction",
       version: "1",
-      chainId: 42_161,
+      chainId: Hyperliquid.Config.signature_chain_id(),
       verifyingContract: "0x0000000000000000000000000000000000000000"
     }
 
@@ -65,7 +65,7 @@ defmodule Hyperliquid.Api.Exchange.CWithdraw do
       action = %{
         type: "cWithdraw",
         hyperliquidChain: if(is_mainnet, do: "Mainnet", else: "Testnet"),
-        signatureChainId: signature_chain_id(is_mainnet),
+        signatureChainId: Hyperliquid.Config.signature_chain_id_hex(),
         wei: wei,
         nonce: nonce
       }
@@ -75,8 +75,6 @@ defmodule Hyperliquid.Api.Exchange.CWithdraw do
       Http.user_signed_request(action, signature, nonce, opts)
     end
   end
-
-  defp signature_chain_id(_is_mainnet), do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/send_asset.ex
+++ b/lib/hyperliquid/api/exchange/send_asset.ex
@@ -5,7 +5,7 @@ defmodule Hyperliquid.Api.Exchange.SendAsset do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#send-asset
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
+  alias Hyperliquid.{Config, Signer}
   alias Hyperliquid.Api.Exchange.KeyUtils
   alias Hyperliquid.Transport.Http
 
@@ -76,7 +76,7 @@ defmodule Hyperliquid.Api.Exchange.SendAsset do
     action =
       Jason.OrderedObject.new([
         {:type, "sendAsset"},
-        {:signatureChainId, signature_chain_id(is_mainnet)},
+        {:signatureChainId, Hyperliquid.Config.signature_chain_id_hex()},
         {:hyperliquidChain, if(is_mainnet, do: "Mainnet", else: "Testnet")},
         {:destination, destination},
         {:sourceDex, source_dex},
@@ -108,7 +108,7 @@ defmodule Hyperliquid.Api.Exchange.SendAsset do
     domain = %{
       name: "HyperliquidSignTransaction",
       version: "1",
-      chainId: 42_161,
+      chainId: Hyperliquid.Config.signature_chain_id(),
       verifyingContract: "0x0000000000000000000000000000000000000000"
     }
 
@@ -155,7 +155,6 @@ defmodule Hyperliquid.Api.Exchange.SendAsset do
 
   # Hyperliquid uses signatureChainId 42161 (Arbitrum One) for BOTH mainnet and testnet.
   # The network distinction is conveyed via the hyperliquidChain field ("Mainnet"/"Testnet").
-  defp signature_chain_id(_is_mainnet), do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/send_to_evm_with_data.ex
+++ b/lib/hyperliquid/api/exchange/send_to_evm_with_data.ex
@@ -5,7 +5,7 @@ defmodule Hyperliquid.Api.Exchange.SendToEvmWithData do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Utils}
+  alias Hyperliquid.Config
   alias Hyperliquid.Api.Exchange.KeyUtils
   alias Hyperliquid.Transport.Http
 
@@ -51,7 +51,7 @@ defmodule Hyperliquid.Api.Exchange.SendToEvmWithData do
     domain = %{
       name: "HyperliquidSignTransaction",
       version: "1",
-      chainId: 42_161,
+      chainId: Hyperliquid.Config.signature_chain_id(),
       verifyingContract: "0x0000000000000000000000000000000000000000"
     }
 
@@ -97,7 +97,7 @@ defmodule Hyperliquid.Api.Exchange.SendToEvmWithData do
       action =
         Jason.OrderedObject.new([
           {:type, "sendToEvmWithData"},
-          {:signatureChainId, signature_chain_id()},
+          {:signatureChainId, Hyperliquid.Config.signature_chain_id_hex()},
           {:hyperliquidChain, if(is_mainnet, do: "Mainnet", else: "Testnet")},
           {:token, token},
           {:amount, amount},
@@ -113,8 +113,6 @@ defmodule Hyperliquid.Api.Exchange.SendToEvmWithData do
       Http.user_signed_request(action, signature, nonce, opts)
     end
   end
-
-  defp signature_chain_id, do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/spot_send.ex
+++ b/lib/hyperliquid/api/exchange/spot_send.ex
@@ -5,9 +5,18 @@ defmodule Hyperliquid.Api.Exchange.SpotSend do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
-  alias Hyperliquid.Api.Exchange.KeyUtils
+  alias Hyperliquid.Config
+  alias Hyperliquid.Api.Exchange.{KeyUtils, UserSigned}
   alias Hyperliquid.Transport.Http
+
+  @primary_type "HyperliquidTransaction:SpotSend"
+  @types [
+    %{name: "hyperliquidChain", type: "string"},
+    %{name: "destination", type: "string"},
+    %{name: "token", type: "string"},
+    %{name: "amount", type: "string"},
+    %{name: "time", type: "uint64"}
+  ]
 
   @doc """
   Send spot tokens to another address.
@@ -40,27 +49,33 @@ defmodule Hyperliquid.Api.Exchange.SpotSend do
     time = generate_nonce()
     is_mainnet = Config.mainnet?()
 
-    sig = Signer.sign_spot_send(private_key, destination, token, amount, time, is_mainnet)
+    hyperliquid_chain = if(is_mainnet, do: "Mainnet", else: "Testnet")
 
-    # IMPORTANT: Use OrderedObject for correct field order in hash calculation
-    # Field order: type, signatureChainId, hyperliquidChain, destination, token, amount, time
-    action =
-      Jason.OrderedObject.new([
-        {:type, "spotSend"},
-        {:signatureChainId, signature_chain_id(is_mainnet)},
-        {:hyperliquidChain, if(is_mainnet, do: "Mainnet", else: "Testnet")},
-        {:destination, destination},
-        {:token, token},
-        {:amount, amount},
-        {:time, time}
-      ])
+    message = %{
+      hyperliquidChain: hyperliquid_chain,
+      destination: destination,
+      token: token,
+      amount: amount,
+      time: time
+    }
 
-    signature = %{r: sig["r"], s: sig["s"], v: sig["v"]}
+    with {:ok, signature} <- UserSigned.sign(private_key, @primary_type, @types, message) do
+      # Field order for the request body: type, signatureChainId,
+      # hyperliquidChain, destination, token, amount, time.
+      action =
+        Jason.OrderedObject.new([
+          {:type, "spotSend"},
+          {:signatureChainId, UserSigned.signature_chain_id()},
+          {:hyperliquidChain, hyperliquid_chain},
+          {:destination, destination},
+          {:token, token},
+          {:amount, amount},
+          {:time, time}
+        ])
 
-    Http.user_signed_request(action, signature, time, opts)
+      Http.user_signed_request(action, signature, time, opts)
+    end
   end
-
-  defp signature_chain_id(_is_mainnet), do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/staking_link_disable_trading_user.ex
+++ b/lib/hyperliquid/api/exchange/staking_link_disable_trading_user.ex
@@ -13,7 +13,7 @@ defmodule Hyperliquid.Api.Exchange.StakingLinkDisableTradingUser do
       {:ok, result} = StakingLinkDisableTradingUser.request("0xabc...")
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
+  alias Hyperliquid.{Config, Signer}
   alias Hyperliquid.Transport.Http
 
   @primary_type "HyperliquidTransaction:StakingLinkDisableTradingUser"
@@ -46,7 +46,7 @@ defmodule Hyperliquid.Api.Exchange.StakingLinkDisableTradingUser do
     domain = %{
       name: "HyperliquidSignTransaction",
       version: "1",
-      chainId: 42_161,
+      chainId: Hyperliquid.Config.signature_chain_id(),
       verifyingContract: "0x0000000000000000000000000000000000000000"
     }
 
@@ -79,7 +79,7 @@ defmodule Hyperliquid.Api.Exchange.StakingLinkDisableTradingUser do
           action =
             Jason.OrderedObject.new([
               {:type, "stakingLinkDisableTradingUser"},
-              {:signatureChainId, Utils.from_int(42_161)},
+              {:signatureChainId, Hyperliquid.Config.signature_chain_id_hex()},
               {:hyperliquidChain, hyperliquid_chain},
               {:tradingUser, trading_user},
               {:nonce, nonce}

--- a/lib/hyperliquid/api/exchange/token_delegate.ex
+++ b/lib/hyperliquid/api/exchange/token_delegate.ex
@@ -5,7 +5,7 @@ defmodule Hyperliquid.Api.Exchange.TokenDelegate do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Utils}
+  alias Hyperliquid.Config
   alias Hyperliquid.Api.Exchange.KeyUtils
   alias Hyperliquid.Transport.Http
 
@@ -41,7 +41,7 @@ defmodule Hyperliquid.Api.Exchange.TokenDelegate do
     domain = %{
       name: "HyperliquidSignTransaction",
       version: "1",
-      chainId: 42_161,
+      chainId: Hyperliquid.Config.signature_chain_id(),
       verifyingContract: "0x0000000000000000000000000000000000000000"
     }
 
@@ -77,7 +77,7 @@ defmodule Hyperliquid.Api.Exchange.TokenDelegate do
       action = %{
         type: "tokenDelegate",
         hyperliquidChain: if(is_mainnet, do: "Mainnet", else: "Testnet"),
-        signatureChainId: signature_chain_id(),
+        signatureChainId: Hyperliquid.Config.signature_chain_id_hex(),
         validator: validator,
         isUndelegate: is_undelegate,
         wei: wei,
@@ -87,8 +87,6 @@ defmodule Hyperliquid.Api.Exchange.TokenDelegate do
       Http.user_signed_request(action, signature, nonce, opts)
     end
   end
-
-  defp signature_chain_id, do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/usd_send.ex
+++ b/lib/hyperliquid/api/exchange/usd_send.ex
@@ -5,9 +5,17 @@ defmodule Hyperliquid.Api.Exchange.UsdSend do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
-  alias Hyperliquid.Api.Exchange.KeyUtils
+  alias Hyperliquid.Config
+  alias Hyperliquid.Api.Exchange.{KeyUtils, UserSigned}
   alias Hyperliquid.Transport.Http
+
+  @primary_type "HyperliquidTransaction:UsdSend"
+  @types [
+    %{name: "hyperliquidChain", type: "string"},
+    %{name: "destination", type: "string"},
+    %{name: "amount", type: "string"},
+    %{name: "time", type: "uint64"}
+  ]
 
   @doc """
   Send USD to another address.
@@ -40,27 +48,32 @@ defmodule Hyperliquid.Api.Exchange.UsdSend do
     time = generate_nonce()
     is_mainnet = Config.mainnet?()
 
-    sig = Signer.sign_usd_send(private_key, destination, amount, time, is_mainnet)
+    hyperliquid_chain = if(is_mainnet, do: "Mainnet", else: "Testnet")
 
-    # IMPORTANT: Use OrderedObject for correct field order in hash calculation
-    # Field order: type, signatureChainId, hyperliquidChain, destination, amount, time
-    action =
-      Jason.OrderedObject.new([
-        {:type, "usdSend"},
-        {:signatureChainId, signature_chain_id(is_mainnet)},
-        {:hyperliquidChain, if(is_mainnet, do: "Mainnet", else: "Testnet")},
-        {:destination, destination},
-        {:amount, amount},
-        {:time, time}
-      ])
+    message = %{
+      hyperliquidChain: hyperliquid_chain,
+      destination: destination,
+      amount: amount,
+      time: time
+    }
 
-    signature = %{r: sig["r"], s: sig["s"], v: sig["v"]}
+    with {:ok, signature} <-
+           UserSigned.sign(private_key, @primary_type, @types, message) do
+      # Field order for the request body: type, signatureChainId,
+      # hyperliquidChain, destination, amount, time.
+      action =
+        Jason.OrderedObject.new([
+          {:type, "usdSend"},
+          {:signatureChainId, UserSigned.signature_chain_id()},
+          {:hyperliquidChain, hyperliquid_chain},
+          {:destination, destination},
+          {:amount, amount},
+          {:time, time}
+        ])
 
-    Http.user_signed_request(action, signature, time, opts)
+      Http.user_signed_request(action, signature, time, opts)
+    end
   end
-
-  # Hyperliquid uses signatureChainId 42161 (Arbitrum One) for BOTH mainnet and testnet.
-  defp signature_chain_id(_is_mainnet), do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/user_set_abstraction.ex
+++ b/lib/hyperliquid/api/exchange/user_set_abstraction.ex
@@ -7,7 +7,7 @@ defmodule Hyperliquid.Api.Exchange.UserSetAbstraction do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Utils}
+  alias Hyperliquid.Config
   alias Hyperliquid.Api.Exchange.KeyUtils
   alias Hyperliquid.Transport.Http
 
@@ -39,7 +39,7 @@ defmodule Hyperliquid.Api.Exchange.UserSetAbstraction do
     domain = %{
       name: "HyperliquidSignTransaction",
       version: "1",
-      chainId: 42_161,
+      chainId: Hyperliquid.Config.signature_chain_id(),
       verifyingContract: "0x0000000000000000000000000000000000000000"
     }
 
@@ -71,7 +71,7 @@ defmodule Hyperliquid.Api.Exchange.UserSetAbstraction do
       action = %{
         type: "userSetAbstraction",
         hyperliquidChain: if(is_mainnet, do: "Mainnet", else: "Testnet"),
-        signatureChainId: signature_chain_id(),
+        signatureChainId: Hyperliquid.Config.signature_chain_id_hex(),
         abstraction: abstraction,
         nonce: nonce
       }
@@ -79,8 +79,6 @@ defmodule Hyperliquid.Api.Exchange.UserSetAbstraction do
       Http.user_signed_request(action, signature, nonce, opts)
     end
   end
-
-  defp signature_chain_id, do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/api/exchange/user_signed.ex
+++ b/lib/hyperliquid/api/exchange/user_signed.ex
@@ -1,0 +1,76 @@
+defmodule Hyperliquid.Api.Exchange.UserSigned do
+  @moduledoc """
+  Shared EIP-712 signing for user-signed exchange actions.
+
+  User-signed actions (withdrawals, transfers, agent approvals) are signed over
+  typed data rather than over the msgpack of the action, so field order does not
+  affect the signature — but the EIP-712 domain does.
+
+  The domain's `chainId` and the action's `signatureChainId` must always agree:
+  the exchange rebuilds the domain from `signatureChainId` to recover the signer,
+  so if they drift the API recovers the wrong address and rejects the action.
+  Both come from `Hyperliquid.Config.signature_chain_id/0`, which is what keeps
+  them in step.
+  """
+
+  alias Hyperliquid.{Config, Signer}
+
+  @verifying_contract "0x0000000000000000000000000000000000000000"
+
+  @doc """
+  The EIP-712 domain used for every user-signed action.
+  """
+  @spec domain() :: map()
+  def domain do
+    %{
+      name: "HyperliquidSignTransaction",
+      version: "1",
+      chainId: Config.signature_chain_id(),
+      verifyingContract: @verifying_contract
+    }
+  end
+
+  @doc """
+  `"Mainnet"` or `"Testnet"`, the field that actually selects the network.
+  """
+  @spec hyperliquid_chain() :: String.t()
+  def hyperliquid_chain, do: if(Config.mainnet?(), do: "Mainnet", else: "Testnet")
+
+  @doc """
+  The `signatureChainId` field to send in the action body.
+  """
+  @spec signature_chain_id() :: String.t()
+  def signature_chain_id, do: Config.signature_chain_id_hex()
+
+  @doc """
+  Sign a user-signed action's typed data.
+
+  ## Parameters
+    - `private_key`: Private key for signing
+    - `primary_type`: EIP-712 primary type, e.g. `"HyperliquidTransaction:UsdSend"`
+    - `types`: List of `%{name: ..., type: ...}` field descriptors, in order
+    - `message`: The message to sign
+
+  ## Returns
+    - `{:ok, %{r: ..., s: ..., v: ...}}`
+    - `{:error, {:signing_error, term()}}`
+  """
+  @spec sign(String.t(), String.t(), [map()], map()) ::
+          {:ok, map()} | {:error, term()}
+  def sign(private_key, primary_type, types, message) do
+    with {:ok, domain_json} <- Jason.encode(domain()),
+         {:ok, types_json} <- Jason.encode(%{primary_type => types}),
+         {:ok, message_json} <- Jason.encode(message) do
+      case Signer.sign_typed_data(
+             private_key,
+             domain_json,
+             types_json,
+             message_json,
+             primary_type
+           ) do
+        %{"r" => r, "s" => s, "v" => v} -> {:ok, %{r: r, s: s, v: v}}
+        error -> {:error, {:signing_error, error}}
+      end
+    end
+  end
+end

--- a/lib/hyperliquid/api/exchange/withdraw3.ex
+++ b/lib/hyperliquid/api/exchange/withdraw3.ex
@@ -5,9 +5,17 @@ defmodule Hyperliquid.Api.Exchange.Withdraw3 do
   See: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
   """
 
-  alias Hyperliquid.{Config, Signer, Utils}
-  alias Hyperliquid.Api.Exchange.KeyUtils
+  alias Hyperliquid.Config
+  alias Hyperliquid.Api.Exchange.{KeyUtils, UserSigned}
   alias Hyperliquid.Transport.Http
+
+  @primary_type "HyperliquidTransaction:Withdraw"
+  @types [
+    %{name: "hyperliquidChain", type: "string"},
+    %{name: "destination", type: "string"},
+    %{name: "amount", type: "string"},
+    %{name: "time", type: "uint64"}
+  ]
 
   @doc """
   Initiate a withdrawal request.
@@ -39,23 +47,28 @@ defmodule Hyperliquid.Api.Exchange.Withdraw3 do
     time = generate_nonce()
     is_mainnet = Config.mainnet?()
 
-    sig = Signer.sign_withdraw3(private_key, destination, amount, time, is_mainnet)
+    hyperliquid_chain = if(is_mainnet, do: "Mainnet", else: "Testnet")
 
-    action = %{
-      type: "withdraw3",
-      hyperliquidChain: if(is_mainnet, do: "Mainnet", else: "Testnet"),
-      signatureChainId: signature_chain_id(is_mainnet),
+    message = %{
+      hyperliquidChain: hyperliquid_chain,
       destination: destination,
       amount: amount,
       time: time
     }
 
-    signature = %{r: sig["r"], s: sig["s"], v: sig["v"]}
+    with {:ok, signature} <- UserSigned.sign(private_key, @primary_type, @types, message) do
+      action = %{
+        type: "withdraw3",
+        hyperliquidChain: hyperliquid_chain,
+        signatureChainId: UserSigned.signature_chain_id(),
+        destination: destination,
+        amount: amount,
+        time: time
+      }
 
-    Http.user_signed_request(action, signature, time, opts)
+      Http.user_signed_request(action, signature, time, opts)
+    end
   end
-
-  defp signature_chain_id(_is_mainnet), do: Utils.from_int(42_161)
 
   defp generate_nonce do
     System.system_time(:millisecond)

--- a/lib/hyperliquid/config.ex
+++ b/lib/hyperliquid/config.ex
@@ -114,6 +114,41 @@ defmodule Hyperliquid.Config do
   end
 
   @doc """
+  Returns the chain id used in the EIP-712 domain when signing user-signed
+  actions, as an integer.
+
+  This value has to appear in two places that must always agree: the `chainId`
+  of the EIP-712 domain the signature is produced over, and the
+  `signatureChainId` field sent in the action body. The exchange rebuilds the
+  domain from `signatureChainId` to recover the signer, so if the two drift the
+  API recovers the wrong address and rejects the action. Reading both from here
+  is what keeps them in step — they were previously hardcoded in the Rust NIF
+  and in a dozen Elixir modules independently.
+
+  The value itself is not constrained by the exchange; any chain id works as
+  long as both sides use the same one. The default is `421_614` (`"0x66eee"`,
+  Arbitrum Sepolia), matching the official Python SDK and the nktkas TypeScript
+  SDK, so signatures produced here are byte-comparable with theirs.
+
+  Override with `config :hyperliquid, signature_chain_id: 42_161`.
+  """
+  @default_signature_chain_id 421_614
+
+  @spec signature_chain_id() :: non_neg_integer()
+  def signature_chain_id do
+    Application.get_env(:hyperliquid, :signature_chain_id, @default_signature_chain_id)
+  end
+
+  @doc """
+  Returns `signature_chain_id/0` as the lowercase hex string used for the
+  `signatureChainId` field (e.g. `"0xa4b1"`).
+  """
+  @spec signature_chain_id_hex() :: String.t()
+  def signature_chain_id_hex do
+    Hyperliquid.Utils.from_int(signature_chain_id())
+  end
+
+  @doc """
   Returns whether debug logging is enabled. Defaults to false.
   Controlled via `config :hyperliquid, debug: true/false` or HL_DEBUG env var.
   """

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Hyperliquid.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/skedzior/hyperliquid"
-  @version "0.3.0"
+  @version "0.3.1"
 
   def project do
     [

--- a/native/signer/src/lib.rs
+++ b/native/signer/src/lib.rs
@@ -641,9 +641,16 @@ fn sign_exchange_action_ex<'a>(
 }
 
 fn chain(is_mainnet: bool) -> (u64, String) {
-    // Hyperliquid uses chainId 42161 (Arbitrum One) for BOTH mainnet and testnet.
-    // The network distinction is conveyed via the hyperliquidChain field.
-    let chain_id = 42161u64;
+    // The EIP-712 domain chainId for user-signed actions. The exchange rebuilds
+    // the domain from the action's signatureChainId to recover the signer, so
+    // this only has to agree with whatever the caller sends there — it is not
+    // the network selector. The network distinction is carried by
+    // hyperliquidChain.
+    //
+    // 421614 ("0x66eee") matches the official Python SDK and the nktkas
+    // TypeScript SDK, so signatures are byte-comparable with both. Keep this in
+    // step with Hyperliquid.Config.signature_chain_id/0.
+    let chain_id = 421614u64;
     let hyperliquid_chain = if is_mainnet { "Mainnet" } else { "Testnet" }.to_string();
     (chain_id, hyperliquid_chain)
 }

--- a/test/api/exchange/batch4_actions_test.exs
+++ b/test/api/exchange/batch4_actions_test.exs
@@ -194,7 +194,7 @@ defmodule Hyperliquid.Api.Exchange.Batch4ActionsTest do
       assert action["type"] == "stakingLinkDisableTradingUser"
       assert action["tradingUser"] == @address
       assert action["hyperliquidChain"] in ["Mainnet", "Testnet"]
-      assert action["signatureChainId"] == "0xa4b1"
+      assert action["signatureChainId"] == Hyperliquid.Config.signature_chain_id_hex()
       assert is_integer(action["nonce"])
     end
 

--- a/test/api/exchange/user_signed_test.exs
+++ b/test/api/exchange/user_signed_test.exs
@@ -1,0 +1,177 @@
+defmodule Hyperliquid.Api.Exchange.UserSignedTest do
+  @moduledoc """
+  Guards the invariant that the EIP-712 domain a user-signed action is signed
+  over always matches the `signatureChainId` sent in its body.
+
+  The exchange rebuilds the domain from `signatureChainId` to recover the signer,
+  so if the two drift it recovers the wrong address and rejects the action. That
+  is exactly what happened before e0e67bf, when the domain was hardcoded while
+  `signatureChainId` varied by network.
+  """
+  use ExUnit.Case, async: false
+
+  alias Hyperliquid.Api.Exchange.{
+    ApproveAgent,
+    ApproveBuilderFee,
+    SpotSend,
+    UsdSend,
+    UserSigned,
+    Withdraw3
+  }
+
+  alias Hyperliquid.{Config, Signer}
+
+  @private_key "0x822e9959e022b78423eb653a62ea0020cd283e71a2a8133a6ff2aeffaf373cff"
+  @address "0x1234567890123456789012345678901234567890"
+
+  setup do
+    bypass = Bypass.open()
+    prev_url = Application.get_env(:hyperliquid, :http_url)
+    Application.put_env(:hyperliquid, :http_url, "http://localhost:#{bypass.port}")
+
+    test_pid = self()
+
+    Bypass.stub(bypass, "POST", "/exchange", fn conn ->
+      {:ok, raw, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:body, Jason.decode!(raw)})
+
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(%{"status" => "ok"}))
+    end)
+
+    on_exit(fn ->
+      if prev_url,
+        do: Application.put_env(:hyperliquid, :http_url, prev_url),
+        else: Application.delete_env(:hyperliquid, :http_url)
+
+      Application.delete_env(:hyperliquid, :signature_chain_id)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  describe "domain and signatureChainId agree" do
+    test "the domain chainId is the numeric form of signatureChainId" do
+      assert UserSigned.domain().chainId == Config.signature_chain_id()
+
+      # Lowercase hex — the docs spell it "0xa4b1", and an uppercase form was one
+      # of the bugs fixed in e0e67bf.
+      assert UserSigned.signature_chain_id() ==
+               "0x" <> String.downcase(Integer.to_string(Config.signature_chain_id(), 16))
+
+      assert UserSigned.signature_chain_id() ==
+               String.downcase(UserSigned.signature_chain_id())
+    end
+
+    test "usdSend sends the configured signatureChainId" do
+      assert {:ok, _} = UsdSend.request(@address, "1", private_key: @private_key)
+      assert_sent_chain_id()
+    end
+
+    test "withdraw3 sends the configured signatureChainId" do
+      assert {:ok, _} = Withdraw3.request(@address, "1", private_key: @private_key)
+      assert_sent_chain_id()
+    end
+
+    test "spotSend sends the configured signatureChainId" do
+      assert {:ok, _} = SpotSend.request(@address, "USDC", "1", private_key: @private_key)
+      assert_sent_chain_id()
+    end
+
+    test "approveBuilderFee sends the configured signatureChainId" do
+      assert {:ok, _} = ApproveBuilderFee.request(@address, "0.001", private_key: @private_key)
+      assert_sent_chain_id()
+    end
+
+    test "approveAgent sends the configured signatureChainId" do
+      assert {:ok, _} = ApproveAgent.approve(@address, private_key: @private_key)
+      assert_sent_chain_id()
+    end
+  end
+
+  defp assert_sent_chain_id do
+    assert_receive {:body, body}
+    assert body["action"]["signatureChainId"] == Config.signature_chain_id_hex()
+  end
+
+  describe "configuration propagates" do
+    test "overriding signature_chain_id changes both the domain and the body" do
+      Application.put_env(:hyperliquid, :signature_chain_id, 1)
+
+      assert UserSigned.domain().chainId == 1
+      assert UserSigned.signature_chain_id() == "0x1"
+
+      assert {:ok, _} = UsdSend.request(@address, "1", private_key: @private_key)
+
+      assert_receive {:body, body}
+      assert body["action"]["signatureChainId"] == "0x1"
+    end
+
+    test "a different chain id produces a different signature" do
+      Application.put_env(:hyperliquid, :signature_chain_id, 421_614)
+      {:ok, a} = UserSigned.sign(@private_key, "T", [%{name: "x", type: "string"}], %{x: "1"})
+
+      Application.put_env(:hyperliquid, :signature_chain_id, 42_161)
+      {:ok, b} = UserSigned.sign(@private_key, "T", [%{name: "x", type: "string"}], %{x: "1"})
+
+      refute a.r == b.r
+    end
+  end
+
+  describe "the Rust NIF agrees with the generic typed-data path" do
+    # The specialized NIFs build the EIP-712 domain in Rust, while everything
+    # else builds it from Config. These must not diverge — if this fails after a
+    # Config change, the NIF needs rebuilding to match.
+    test "sign_usd_send matches UserSigned.sign/4" do
+      time = 1_234_567_890
+
+      nif = Signer.sign_usd_send(@private_key, @address, "1000", time, true)
+
+      {:ok, generic} =
+        UserSigned.sign(
+          @private_key,
+          "HyperliquidTransaction:UsdSend",
+          [
+            %{name: "hyperliquidChain", type: "string"},
+            %{name: "destination", type: "string"},
+            %{name: "amount", type: "string"},
+            %{name: "time", type: "uint64"}
+          ],
+          %{hyperliquidChain: "Mainnet", destination: @address, amount: "1000", time: time}
+        )
+
+      assert nif["r"] == generic.r
+      assert nif["s"] == generic.s
+      assert nif["v"] == generic.v
+    end
+
+    test "sign_spot_send matches UserSigned.sign/4" do
+      time = 1_234_567_890
+
+      nif = Signer.sign_spot_send(@private_key, @address, "USDC", "1000", time, true)
+
+      {:ok, generic} =
+        UserSigned.sign(
+          @private_key,
+          "HyperliquidTransaction:SpotSend",
+          [
+            %{name: "hyperliquidChain", type: "string"},
+            %{name: "destination", type: "string"},
+            %{name: "token", type: "string"},
+            %{name: "amount", type: "string"},
+            %{name: "time", type: "uint64"}
+          ],
+          %{
+            hyperliquidChain: "Mainnet",
+            destination: @address,
+            token: "USDC",
+            amount: "1000",
+            time: time
+          }
+        )
+
+      assert nif["r"] == generic.r
+    end
+  end
+end


### PR DESCRIPTION
Fixes the failing `usdSend` EIP-712 vector in `SignerUserSignedTest`, the last known-issue carried into v0.3.0.

## What was wrong

The test asserted the signature produced with EIP-712 domain `chainId` 421614 (`0x66eee`) while the library signed with 42161 (`0xa4b1`). Confirmed with `eth-account`:

| domain chainId | resulting `r` |
|---|---|
| 421614 (`0x66eee`) | `0xf777c38e…` ← test expects, reference SDKs use |
| 42161 (`0xa4b1`) | `0xb25362bf…` ← what the library emitted |

**This was not a functional break.** The exchange rebuilds the EIP-712 domain from the action's `signatureChainId` to recover the signer, so only self-consistency matters — and the domain and `signatureChainId` did agree at 42161. Withdrawals and transfers worked. The library simply used a different convention from the official Python SDK and nktkas, which both use `0x66eee` unconditionally.

## What changed

User-signed actions now sign with `0x66eee`, making signatures byte-comparable with both reference SDKs.

The underlying fragility was structural: the chain id lived in the Rust NIF **and** in a dozen Elixir modules independently. That duplication is how the domain and `signatureChainId` drifted apart before `e0e67bf`, which made the API recover the wrong address. Both now read `Hyperliquid.Config.signature_chain_id/0`.

Adds `Hyperliquid.Api.Exchange.UserSigned` for the shared domain and signing. The five actions that signed through specialized Rust NIFs (`usdSend`, `withdraw3`, `spotSend`, `approveAgent`, `approveBuilderFee`) now route through it so configuration actually reaches them — verified byte-identical to the NIF path for all five *before* switching. A nil agent name still signs over `""`, matching how rustler decoded it.

New tests pin domain ↔ `signatureChainId` across all five actions, assert the config override propagates to both, and assert the Rust NIF still agrees with the generic path so the two cannot silently diverge.

## Reviewer note: both conventions exist in the wild

`test/debug/send_asset_debug_test.exs` contains payloads **captured from the Hyperliquid frontend**, and the frontend sends `"signatureChainId": "0xa4b1"` on testnet. So 42161 was not arbitrary — it is what the frontend does, which is presumably why `e0e67bf` chose it.

This change moves from the frontend's convention to the SDKs'. Both are accepted by the exchange. It does change the signing bytes for every user-signed action (withdrawals, USD sends, spot sends, agent approvals), so a testnet transfer is worth running before relying on it. Reverting is one line and needs no rebuild:

```elixir
config :hyperliquid, signature_chain_id: 42_161
```

## Testing

280 tests, **25 failures — down from 26**, with `SignerUserSignedTest` now green and no new failures. The remaining 25 are the same pre-existing set (15 Postgres/storage needing a live DB, 4 RPC, 4 debug, 2 info).

Note the 4 `SendAssetDebugTest` failures are not a real signal: `@api_key` is the literal placeholder `"YOUR_API_KEY_HERE"`, so both signing calls error identically and the "different chainIds must produce different signatures" assertion fails on equal error tuples. They have never been runnable as checked in.

Requires rebuilt precompiled NIFs — the Rust `chain/1` default moved to 421614 so the standalone `Signer.sign_*` functions stay in step with `Config.signature_chain_id/0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)