### PR TITLE
feat(cache): resolve HIP-4 outcome assets + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Elixir SDK for the Hyperliquid decentralized exchange with DSL-based API endpoin
 
 ## Overview
 
-Hyperliquid provides a comprehensive, type-safe interface to the Hyperliquid DEX. The v0.2.0 release introduces a modern DSL-based architecture that eliminates boilerplate while providing response validation, automatic caching, and optional database persistence.
+Hyperliquid provides a comprehensive, type-safe interface to the Hyperliquid DEX. The DSL-based architecture eliminates boilerplate while providing response validation, automatic caching, and optional database persistence. Endpoint coverage tracks the nktkas TypeScript SDK, including HIP-4 prediction markets.
 
 ## Features
 
 - **DSL-based endpoint definitions** - Clean, declarative API with automatic function generation
-- **125+ typed endpoints** - 62 Info endpoints, 38 Exchange endpoints, 26 WebSocket subscriptions
+- **165+ typed endpoints** - 78 Info endpoints, 60 Exchange actions, 31 WebSocket subscriptions
 - **Ecto schema validation** - Built-in response validation and type safety
 - **WebSocket connection pooling** - Efficient connection management with automatic reconnection
 - **Cachex-based caching** - Fast in-memory asset metadata and mid price lookups
@@ -27,7 +27,7 @@ Add `hyperliquid` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:hyperliquid, "~> 0.2.0"}
+    {:hyperliquid, "~> 0.3.1"}
   ]
 end
 ```
@@ -52,7 +52,7 @@ Enable database features by setting `enable_db: true` and adding the required de
 # mix.exs
 defp deps do
   [
-    {:hyperliquid, "~> 0.2.0"},
+    {:hyperliquid, "~> 0.3.1"},
     # Required when enable_db: true
     {:phoenix_ecto, "~> 4.5"},
     {:ecto_sql, "~> 3.10"},
@@ -109,7 +109,49 @@ config :hyperliquid,
   debug: false,
 
   # Private key
-  private_key: "YOUR_PRIVATE_KEY_HERE"
+  private_key: "YOUR_PRIVATE_KEY_HERE",
+
+  # EIP-712 domain chainId for user-signed actions (withdrawals, transfers,
+  # agent approvals). Must match the signatureChainId sent in the action body —
+  # the exchange rebuilds the domain from it to recover the signer, so if the two
+  # disagree it recovers the wrong address and rejects the action. Both are read
+  # from here, so they cannot drift.
+  #
+  # Defaults to 421_614 ("0x66eee"), matching the official Python SDK and the
+  # nktkas TypeScript SDK. The Hyperliquid frontend uses 42_161 ("0xa4b1");
+  # either works, as long as it is used consistently.
+  signature_chain_id: 421_614,
+
+  # szDecimals for HIP-4 outcome assets. outcomeMeta does not publish this and
+  # outcome tokens are absent from spotMeta, so there is no authoritative source.
+  # Too large a value makes the exchange reject the order, too small truncates
+  # the size — confirm against a real outcome order before relying on it.
+  outcome_sz_decimals: 2
+```
+
+### HIP-4 prediction markets
+
+Outcome assets use their own encoding, derived from an outcome id plus a binary
+side as `outcome * 10 + side`:
+
+| representation | form | example |
+| --- | --- | --- |
+| spot coin | `#<encoding>` | `#70020` |
+| token name | `+<encoding>` | `+70020` |
+| asset ID | `100_000_000 + encoding` | `100070020` |
+
+They appear in neither `spotMeta`'s universe nor its token list, so the cache
+resolves them from `outcomeMeta`:
+
+```elixir
+Hyperliquid.Cache.outcome_coin(7002, 0)      # => "#70020"
+Hyperliquid.Cache.outcome_asset(7002, 0)     # => 100070020
+Hyperliquid.Cache.outcome_and_side("#70020") # => {:ok, {7002, 0}}
+Hyperliquid.Cache.asset_from_coin("#70020")  # => 100070020
+
+# Outcome coins work anywhere a coin is accepted
+Hyperliquid.Api.Info.L2Book.request("#70020")
+Hyperliquid.Api.Exchange.Order.limit_order("#70020", true, "0.5", "1")
 ```
 
 ## Quick Start
@@ -278,7 +320,7 @@ The Info API provides read-only market and account information. All endpoints ar
 - `Delegations` - User delegations
 - `DelegatorRewards` - Delegation rewards
 
-See the [HexDocs](https://hexdocs.pm/hyperliquid) for the complete list of 62 Info endpoints.
+See the [HexDocs](https://hexdocs.pm/hyperliquid) for the complete list of 78 Info endpoints.
 
 ### Exchange API (Trading Operations)
 
@@ -301,7 +343,7 @@ The Exchange API handles all trading operations. All endpoints are located in `H
 - `CreateVault` - Create a new vault
 - `VaultTransfer` - Vault deposits/withdrawals
 
-See the [HexDocs](https://hexdocs.pm/hyperliquid) for the complete list of 38 Exchange endpoints.
+See the [HexDocs](https://hexdocs.pm/hyperliquid) for the complete list of 60 Exchange actions.
 
 ### Subscription API (Real-time Updates)
 
@@ -323,7 +365,7 @@ The Subscription API provides WebSocket channels for real-time data. All endpoin
 - `ExplorerBlock` - New blocks (shared connection)
 - `ExplorerTxs` - Transactions (shared connection)
 
-See the [HexDocs](https://hexdocs.pm/hyperliquid) for the complete list of 26 subscription channels.
+See the [HexDocs](https://hexdocs.pm/hyperliquid) for the complete list of 31 subscription channels.
 
 ## Endpoint DSL
 
@@ -533,7 +575,7 @@ Use Hyperliquid in Livebook for interactive trading and analysis:
 
 ```elixir
 Mix.install([
-  {:hyperliquid, "~> 0.2.0"}
+  {:hyperliquid, "~> 0.3.1"}
 ],
 config: [
   hyperliquid: [
@@ -550,7 +592,7 @@ alias Hyperliquid.Api.Info.AllMids
 
 ```elixir
 Mix.install([
-  {:hyperliquid, "~> 0.2.0"}
+  {:hyperliquid, "~> 0.3.1"}
 ],
 config: [
   hyperliquid: [

--- a/lib/hyperliquid/cache.ex
+++ b/lib/hyperliquid/cache.ex
@@ -89,12 +89,14 @@ defmodule Hyperliquid.Cache do
     cache_init_start = System.monotonic_time()
     debug("Cache.init_with_partial_success starting...")
 
-    # Fetch all 4 data sources
+    # Fetch all data sources. outcome_meta is the only source for HIP-4 outcome
+    # assets — they do not appear in spotMeta.
     fetches = [
       {:meta, fn -> Http.meta_and_asset_ctxs() end},
       {:spot_meta, fn -> Http.spot_meta_and_asset_ctxs() end},
       {:mids, fn -> Http.all_mids(raw: true) end},
-      {:perp_dexs, fn -> Http.perp_dexs() end}
+      {:perp_dexs, fn -> Http.perp_dexs() end},
+      {:outcome_meta, fn -> Http.outcome_meta(raw: true) end}
     ]
 
     results =
@@ -124,10 +126,14 @@ defmodule Hyperliquid.Cache do
       store_successful_fetches(success_map)
     end
 
-    # Return appropriate result based on success/failure counts
+    # Return appropriate result based on success/failure counts. Counted against
+    # the number of fetches rather than a literal, so adding a source does not
+    # silently turn a full success into a reported partial one.
+    total_fetches = length(fetches)
+
     result =
       case {length(successes), length(failures)} do
-        {4, 0} ->
+        {^total_fetches, 0} ->
           debug("Cache.init_with_partial_success completed successfully")
           :ok
 
@@ -259,9 +265,26 @@ defmodule Hyperliquid.Cache do
         {%{}, %{}, nil, nil}
       end
 
+    # Process HIP-4 outcome meta if available. Outcome assets are absent from
+    # spotMeta, so without this they cannot be resolved at all.
+    outcome_meta_data = Map.get(success_map, :outcome_meta)
+
+    {outcome_asset_map, outcome_decimal_map} =
+      if outcome_meta_data do
+        {map, decimals} = build_outcome_maps(outcome_meta_data)
+
+        debug("Processing outcome meta", %{outcome_assets: map_size(map)})
+
+        {map, decimals}
+      else
+        {%{}, %{}}
+      end
+
     # Merge maps
-    asset_map = Map.merge(perp_asset_map, spot_asset_map)
-    decimal_map = Map.merge(perp_decimal_map, spot_decimal_map)
+    asset_map = perp_asset_map |> Map.merge(spot_asset_map) |> Map.merge(outcome_asset_map)
+
+    decimal_map =
+      perp_decimal_map |> Map.merge(spot_decimal_map) |> Map.merge(outcome_decimal_map)
 
     debug("Merged maps", %{
       total_assets: map_size(asset_map),
@@ -276,7 +299,7 @@ defmodule Hyperliquid.Cache do
 
     asset_to_price_decimals =
       Enum.reduce(asset_to_sz_decimals, %{}, fn {asset, sz_dec}, acc ->
-        max_decimals = if asset >= 10_000 and asset < 100_000, do: 8, else: 6
+        max_decimals = max_decimals_for_asset(asset)
         allowed = max(max_decimals - (sz_dec || 0), 0)
         Map.put(acc, asset, allowed)
       end)
@@ -426,7 +449,7 @@ defmodule Hyperliquid.Cache do
 
       asset_to_price_decimals =
         Enum.reduce(asset_to_sz_decimals, %{}, fn {asset, sz_dec}, acc ->
-          max_decimals = if asset >= 10_000 and asset < 100_000, do: 8, else: 6
+          max_decimals = max_decimals_for_asset(asset)
           allowed = max(max_decimals - (sz_dec || 0), 0)
           Map.put(acc, asset, allowed)
         end)
@@ -554,6 +577,142 @@ defmodule Hyperliquid.Cache do
           price when is_float(price) -> price
         end
     end
+  end
+
+  # ===================== HIP-4 outcome assets =====================
+
+  # Outcome assets are derived from an outcome id plus a binary side, encoded as
+  # `outcome * 10 + side`. The same encoding appears three ways:
+  #
+  #   spot coin   "#<encoding>"
+  #   token name  "+<encoding>"
+  #   asset ID    100_000_000 + encoding
+  #
+  # See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids
+  @outcome_asset_base 100_000_000
+
+  @doc """
+  The asset ID base for HIP-4 outcome assets.
+  """
+  @spec outcome_asset_base() :: pos_integer()
+  def outcome_asset_base, do: @outcome_asset_base
+
+  @doc """
+  Whether an asset ID refers to a HIP-4 outcome asset.
+
+  ## Example
+
+      Hyperliquid.Cache.outcome_asset?(100_070_020)
+      # => true
+  """
+  @spec outcome_asset?(term()) :: boolean()
+  def outcome_asset?(asset) when is_integer(asset), do: asset >= @outcome_asset_base
+  def outcome_asset?(_), do: false
+
+  @doc """
+  Whether a coin string refers to a HIP-4 outcome asset.
+
+  ## Example
+
+      Hyperliquid.Cache.outcome_coin?("#70020")
+      # => true
+  """
+  @spec outcome_coin?(term()) :: boolean()
+  def outcome_coin?(coin) when is_binary(coin), do: String.starts_with?(coin, "#")
+  def outcome_coin?(_), do: false
+
+  @doc """
+  Build the coin string for an outcome id and side.
+
+  Only sides `0` and `1` are valid.
+
+  ## Example
+
+      Hyperliquid.Cache.outcome_coin(7002, 0)
+      # => "#70020"
+  """
+  @spec outcome_coin(non_neg_integer(), 0 | 1) :: String.t()
+  def outcome_coin(outcome, side) when is_integer(outcome) and side in [0, 1] do
+    "#" <> Integer.to_string(outcome_encoding(outcome, side))
+  end
+
+  @doc """
+  Build the asset ID for an outcome id and side.
+
+  ## Example
+
+      Hyperliquid.Cache.outcome_asset(7002, 0)
+      # => 100070020
+  """
+  @spec outcome_asset(non_neg_integer(), 0 | 1) :: pos_integer()
+  def outcome_asset(outcome, side) when is_integer(outcome) and side in [0, 1] do
+    @outcome_asset_base + outcome_encoding(outcome, side)
+  end
+
+  @doc """
+  Recover `{outcome, side}` from an outcome coin or asset ID.
+
+  ## Returns
+    - `{:ok, {outcome, side}}`
+    - `{:error, :not_an_outcome}`
+
+  ## Example
+
+      Hyperliquid.Cache.outcome_and_side("#70020")
+      # => {:ok, {7002, 0}}
+  """
+  @spec outcome_and_side(String.t() | integer()) ::
+          {:ok, {non_neg_integer(), 0 | 1}} | {:error, :not_an_outcome}
+  def outcome_and_side("#" <> encoding) do
+    case Integer.parse(encoding) do
+      {value, ""} -> {:ok, {div(value, 10), rem(value, 10)}}
+      _ -> {:error, :not_an_outcome}
+    end
+  end
+
+  def outcome_and_side(asset) when is_integer(asset) and asset >= @outcome_asset_base do
+    encoding = asset - @outcome_asset_base
+    {:ok, {div(encoding, 10), rem(encoding, 10)}}
+  end
+
+  def outcome_and_side(_), do: {:error, :not_an_outcome}
+
+  defp outcome_encoding(outcome, side), do: outcome * 10 + side
+
+  # Outcomes trade like spot, so they take the spot price-decimal ceiling rather
+  # than the perp one.
+  defp max_decimals_for_asset(asset) do
+    cond do
+      outcome_asset?(asset) -> 8
+      asset >= 10_000 and asset < 100_000 -> 8
+      true -> 6
+    end
+  end
+
+  # outcomeMeta gives no szDecimals, and outcome tokens are absent from spotMeta,
+  # so there is no authoritative source for it. Configurable rather than guessed
+  # silently, since an over-large value makes the exchange reject the order and an
+  # under-large one truncates the size.
+  defp outcome_sz_decimals do
+    Application.get_env(:hyperliquid, :outcome_sz_decimals, 2)
+  end
+
+  defp build_outcome_maps(outcome_meta) do
+    outcomes = Map.get(outcome_meta, "outcomes") || Map.get(outcome_meta, :outcomes) || []
+    sz_decimals = outcome_sz_decimals()
+
+    Enum.reduce(outcomes, {%{}, %{}}, fn outcome, {assets, decimals} ->
+      id = Map.get(outcome, "outcome") || Map.get(outcome, :outcome)
+
+      if is_integer(id) do
+        Enum.reduce(0..1, {assets, decimals}, fn side, {a, d} ->
+          coin = outcome_coin(id, side)
+          {Map.put(a, coin, outcome_asset(id, side)), Map.put(d, coin, sz_decimals)}
+        end)
+      else
+        {assets, decimals}
+      end
+    end)
   end
 
   @doc """
@@ -916,6 +1075,23 @@ defmodule Hyperliquid.Cache do
 
   def query_asset(asset) when is_integer(asset) do
     cond do
+      outcome_asset?(asset) ->
+        case outcome_and_side(asset) do
+          {:ok, {outcome, side}} ->
+            %{
+              type: :outcome,
+              asset: asset,
+              coin: outcome_coin(outcome, side),
+              outcome: outcome,
+              side: side,
+              sz_decimals: sz_decimals_by_asset(asset),
+              price_decimals: price_decimals_by_asset(asset)
+            }
+
+          _ ->
+            nil
+        end
+
       asset >= 10_000 and asset < 100_000 ->
         case get_spot_by_asset(asset) do
           nil ->

--- a/lib/hyperliquid/transport/http.ex
+++ b/lib/hyperliquid/transport/http.ex
@@ -530,6 +530,17 @@ defmodule Hyperliquid.Transport.Http do
   end
 
   @doc """
+  Fetch HIP-4 prediction market outcome metadata.
+
+  Outcome assets are not present in `spotMeta`, so this is the only source for
+  resolving `#<encoding>` coins to asset IDs.
+  """
+  @spec outcome_meta(request_opts()) :: response()
+  def outcome_meta(opts \\ []) do
+    info_request(%{type: "outcomeMeta"}, opts)
+  end
+
+  @doc """
   Fetch limits for a specific perpetual DEX.
 
   ## Parameters

--- a/test/cache_outcome_assets_test.exs
+++ b/test/cache_outcome_assets_test.exs
@@ -1,0 +1,96 @@
+defmodule Hyperliquid.CacheOutcomeAssetsTest do
+  @moduledoc """
+  HIP-4 outcome asset encoding.
+
+  Outcome assets are absent from `spotMeta`, so `outcomeMeta` is the only source
+  for them. Encoding is `outcome * 10 + side`, surfacing three ways:
+
+      spot coin   "#<encoding>"
+      token name  "+<encoding>"
+      asset ID    100_000_000 + encoding
+
+  Verified against testnet: the 309 live outcomes expand to exactly the 618
+  `#`-prefixed coins that `allMids` returns, with no difference in either
+  direction.
+  """
+  use ExUnit.Case, async: true
+
+  alias Hyperliquid.Cache
+
+  describe "encoding" do
+    test "builds coins from outcome and side" do
+      assert Cache.outcome_coin(1, 0) == "#10"
+      assert Cache.outcome_coin(1, 1) == "#11"
+      assert Cache.outcome_coin(7002, 0) == "#70020"
+      assert Cache.outcome_coin(7002, 1) == "#70021"
+    end
+
+    test "builds asset ids from outcome and side" do
+      assert Cache.outcome_asset(1, 0) == 100_000_010
+      assert Cache.outcome_asset(7002, 0) == 100_070_020
+      assert Cache.outcome_asset(7002, 1) == 100_070_021
+    end
+
+    test "matches the documented example" do
+      # "#10 = outcome 1, side 0", asset id 100000010
+      assert Cache.outcome_coin(1, 0) == "#10"
+      assert Cache.outcome_asset(1, 0) == 100_000_010
+      assert Cache.outcome_and_side("#10") == {:ok, {1, 0}}
+      assert Cache.outcome_and_side(100_000_010) == {:ok, {1, 0}}
+    end
+
+    test "round-trips coin and asset id" do
+      for outcome <- [0, 1, 7, 42, 7002, 119_38], side <- [0, 1] do
+        coin = Cache.outcome_coin(outcome, side)
+        asset = Cache.outcome_asset(outcome, side)
+
+        assert Cache.outcome_and_side(coin) == {:ok, {outcome, side}}
+        assert Cache.outcome_and_side(asset) == {:ok, {outcome, side}}
+      end
+    end
+
+    test "rejects invalid sides" do
+      assert_raise FunctionClauseError, fn -> Cache.outcome_coin(1, 2) end
+      assert_raise FunctionClauseError, fn -> Cache.outcome_asset(1, -1) end
+    end
+  end
+
+  describe "classification" do
+    test "recognises outcome coins" do
+      assert Cache.outcome_coin?("#10")
+      assert Cache.outcome_coin?("#70020")
+      refute Cache.outcome_coin?("BTC")
+      refute Cache.outcome_coin?("HYPE/USDC")
+      refute Cache.outcome_coin?("@107")
+      refute Cache.outcome_coin?(nil)
+    end
+
+    test "recognises outcome asset ids without colliding with perps or spot" do
+      assert Cache.outcome_asset?(100_000_000)
+      assert Cache.outcome_asset?(100_070_020)
+
+      # perps
+      refute Cache.outcome_asset?(0)
+      refute Cache.outcome_asset?(3)
+      # spot
+      refute Cache.outcome_asset?(10_000)
+      refute Cache.outcome_asset?(10_107)
+      # builder-deployed perps
+      refute Cache.outcome_asset?(110_000)
+      refute Cache.outcome_asset?(120_000)
+
+      refute Cache.outcome_asset?("100000010")
+    end
+
+    test "outcome_and_side rejects non-outcomes" do
+      assert Cache.outcome_and_side("BTC") == {:error, :not_an_outcome}
+      assert Cache.outcome_and_side("#nope") == {:error, :not_an_outcome}
+      assert Cache.outcome_and_side(10_107) == {:error, :not_an_outcome}
+      assert Cache.outcome_and_side(nil) == {:error, :not_an_outcome}
+    end
+
+    test "the asset base is the documented constant" do
+      assert Cache.outcome_asset_base() == 100_000_000
+    end
+  end
+end


### PR DESCRIPTION
Outcome coins were unresolvable. `asset_map` held zero of them, `asset_from_coin/1` returned `nil` for every `#` coin, and order building failed:

```
Order.limit_order("#102190", true, "0.5", "1") → {:error, {:coin_not_found, "#102190"}}
```

Outcome markets could be watched but not traded.

## Cause

Outcome assets appear in neither `spotMeta`'s universe nor its token list — `outcomeMeta` is their only source, and the cache never fetched it.

## Fix

`Cache.init/0` now fetches `outcomeMeta` and expands each outcome into its two sides using the documented encoding (`outcome * 10 + side`):

| representation | form | example |
| --- | --- | --- |
| spot coin | `#<encoding>` | `#70020` |
| asset ID | `100_000_000 + encoding` | `100070020` |

**Validated against live testnet data:** the 309 live outcomes expand to exactly the 618 `#`-prefixed coins `allMids` returns — identical sets, no difference in either direction. That checks the encoding against the exchange rather than only against the docs.

```
asset_from_coin("#102190") → 100102190
limit_order("#102190", ...) → asset: 100102190
```

Also in scope:

- `max_decimals_for_asset/1` replaces two copies of an inline range check that classified outcome assets as perps, allowing 6 price decimals instead of the spot-like 8.
- `query_asset/1` gains an `:outcome` branch; it previously fell through to the perp lookup and returned `nil`.
- The success check in `init_with_partial_success/0` counted against a literal `4`, so adding a fifth source would have reported every full success as partial.
- Adds `outcome_coin/2`, `outcome_asset/2`, `outcome_and_side/1`, `outcome_coin?/1`, `outcome_asset?/1`, `outcome_asset_base/0`.

## Channels already worked

`l2Book`, `trades`, `candle`, `bbo`, `activeAssetCtx` and `activeAssetData` pass the coin through unvalidated and the API accepts `#` directly. Verified live — `l2Book("#102190")` returns a book. No change needed there.

## One value with no authoritative source

`szDecimals` is not published for outcomes: `outcomeMeta` omits it, outcome tokens are absent from `spotMeta`, and none of the 309 live outcomes carry a side token id to resolve. It is therefore configurable rather than silently guessed:

```elixir
config :hyperliquid, outcome_sz_decimals: 2  # default
```

Too large a value makes the exchange reject the order, too small truncates the size, so this should be confirmed against a real outcome order.

## README

Endpoint counts were stale at the v0.2.0 figures (62/38/26); actual coverage is 78/60/31. Install snippets still pinned `~> 0.2.0`. Adds documentation for `signature_chain_id` and `outcome_sz_decimals` — both have failure modes worth stating rather than discovering — plus a HIP-4 encoding section.

## Testing

289 tests, 25 pre-existing failures, no new ones. 9 new tests cover the encoding, round-tripping, and that outcome asset IDs don't collide with perps, spot, or builder-deployed perps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)