### PR TITLE
feat: local node client (info + EVM RPC) and WebSocket rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ config/prod.secret.exs
 # Debug test files (local only)
 /test/debug/
 notebooks/exchange_testing.livemd
+scripts/arb_analysis.exs
+.claude/skills/release.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added `Hyperliquid.Node` module for interacting with local Hyperliquid node endpoints
+- 29 generated convenience functions for documented local info server endpoints with struct parsing
+- Generic `info_request/2` fallback for undocumented or future node endpoints
+- File snapshot helpers (`file_snapshot/3`, `referrer_states_snapshot/2`, `l4_snapshots/2`)
+- EVM RPC helpers via `:node` named RPC (`rpc_call/2`, `rpc_call!/2`)
+- Added `node_info_request/2` to `Hyperliquid.Transport.Http`
+- Independent `enable_node_info` and `enable_node_rpc` config flags
+- Added `node_url/0`, `node_rpc_enabled?/0`, `node_info_enabled?/0` to `Hyperliquid.Config`
+
 ## 0.3.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@
 ### Added
 
 - Added `Hyperliquid.Node` module for interacting with local Hyperliquid node endpoints
-- 29 generated convenience functions for documented local info server endpoints with struct parsing
+- 42 generated convenience functions for verified local info server endpoints with struct parsing
+- Added 7 new endpoints: `allPerpMetas`, `allBorrowLendReserveStates`, `spotPairDeployAuctionStatus`, `subAccounts2`, `userDexAbstraction`, `alignedQuoteTokenInfo`, `perpDexLimits`
+- Added 6 more node-verified info endpoints: `perpCategories`, `userAbstraction`, `approvedBuilders`, `borrowLendUserState`, `borrowLendReserveState`, `perpAnnotation`
+- Optional `dex:` keyword arg support on `meta`, `clearinghouseState`, `openOrders`, `frontendOpenOrders`, `perpsAtOpenInterestCap`
+- Refactored `@supported_endpoints` to 5-tuple format `{name, type, mod, required, optional}` for clean optional param generation
+- Fixed `marginTable` to accept required `id` parameter
+- Added generic single-param macro case for non-user params (`id`, `token`, `dex`)
+- Documented full list of supported and unsupported local node endpoints
+- Added new exchange endpoints: `BorrowLend`, `PerpDeploy`, `SpotDeploy`, `SpotUser`, `UserDexAbstraction`, `UserPortfolioMargin`
+- Added new info endpoint: `UserBorrowLendInterest`
+- Added new WebSocket subscriptions: `AllDexsAssetCtxs`, `AllDexsClearinghouseState`
 - Generic `info_request/2` fallback for undocumented or future node endpoints
 - File snapshot helpers (`file_snapshot/3`, `referrer_states_snapshot/2`, `l4_snapshots/2`)
 - EVM RPC helpers via `:node` named RPC (`rpc_call/2`, `rpc_call!/2`)

--- a/README.md
+++ b/README.md
@@ -625,16 +625,37 @@ config :hyperliquid,
 
 ### Info Endpoints
 
-Convenience functions are generated for all documented local info endpoints, with automatic struct parsing:
+Convenience functions are generated for all verified local info endpoints, with automatic struct parsing:
 
 ```elixir
 alias Hyperliquid.Node
 
-# Parsed struct responses (same types as the public API)
+# No-param endpoints
 {:ok, meta} = Node.meta()
+{:ok, status} = Node.exchange_status()
+{:ok, metas} = Node.all_perp_metas()
+{:ok, reserves} = Node.all_borrow_lend_reserve_states()
+{:ok, spot} = Node.spot_meta()
+
+# User-param endpoints
 {:ok, state} = Node.clearinghouse_state("0x...")
 {:ok, orders} = Node.open_orders("0x...")
-{:ok, status} = Node.exchange_status()
+{:ok, fees} = Node.user_fees("0x...")
+{:ok, accounts} = Node.sub_accounts2("0x...")
+{:ok, abstraction} = Node.user_dex_abstraction("0x...")
+
+# Other single-param endpoints
+{:ok, table} = Node.margin_table(56)
+{:ok, info} = Node.aligned_quote_token_info(0)
+{:ok, limits} = Node.perp_dex_limits("some_dex")
+{:ok, reserve} = Node.borrow_lend_reserve_state(0)
+{:ok, ann} = Node.perp_annotation("BTC")
+
+# Endpoints with optional dex: keyword arg
+{:ok, meta} = Node.meta(dex: "some_dex")
+{:ok, state} = Node.clearinghouse_state("0x...", dex: "some_dex")
+{:ok, orders} = Node.open_orders("0x...", dex: "some_dex")
+{:ok, caps} = Node.perps_at_open_interest_cap(dex: "some_dex")
 
 # Generic fallback for any info request (returns raw map)
 {:ok, data} = Node.info_request(%{type: "someEndpoint", user: "0x..."})
@@ -642,6 +663,37 @@ alias Hyperliquid.Node
 # Health check
 {:ok, _} = Node.ping()
 ```
+
+<details>
+<summary>Supported local node info endpoints (42 total)</summary>
+
+**No-param:** `meta`*, `spotMeta`, `allPerpMetas`, `allBorrowLendReserveStates`,
+`exchangeStatus`, `liquidatable`, `vaultSummaries`, `leadingVaults`, `perpDexs`,
+`perpCategories`, `perpDeployAuctionStatus`, `perpsAtOpenInterestCap`*, `spotDeployState`,
+`spotPairDeployAuctionStatus`, `validatorL1Votes`, `maxMarketOrderNtls`
+
+**User-param:** `clearinghouseState`*, `spotClearinghouseState`, `openOrders`*,
+`frontendOpenOrders`*, `extraAgents`, `subAccounts`, `subAccounts2`, `userFees`,
+`userRateLimit`, `userVaultEquities`, `userDexAbstraction`, `userToMultiSigSigners`,
+`userRole`, `userAbstraction`, `approvedBuilders`, `borrowLendUserState`,
+`delegations`, `delegatorSummary`, `maxBuilderFee`, `webData2`
+
+**User+coin:** `activeAssetData`
+
+**Other params:** `marginTable` (id), `alignedQuoteTokenInfo` (token),
+`borrowLendReserveState` (token), `perpAnnotation` (coin), `perpDexLimits` (dex)
+
+\* Supports optional `dex:` keyword arg
+
+**Not supported on local node:** `allMids`, `metaAndAssetCtxs`, `spotMetaAndAssetCtxs`,
+`predictedFundings`, `l2Book`, `recentTrades`, `candleSnapshot`, `fundingHistory`,
+`userFills`, `userFillsByTime`, `userFunding`, `userBorrowLendInterest`,
+`userNonFundingLedgerUpdates`, `historicalOrders`, `orderStatus`, `perpDexStatus`,
+`vaultDetails`, `tokenDetails`, `validatorSummaries`, `gossipRootIps`,
+`portfolio`, `referral`, `isVip`, `legalCheck`, `preTransferCheck`, `twapHistory`,
+`delegatorHistory`, `delegatorRewards`, `userTwapSliceFills`, `userTwapSliceFillsByTime`
+
+</details>
 
 ### File Snapshots
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Hyperliquid provides a comprehensive, type-safe interface to the Hyperliquid DEX
 - **WebSocket connection pooling** - Efficient connection management with automatic reconnection
 - **Cachex-based caching** - Fast in-memory asset metadata and mid price lookups
 - **Optional Postgres persistence** - Config-driven database storage for API data
+- **Local node client** - Low-latency access to local node Info and EVM RPC endpoints
 - **Testnet/mainnet support** - Easy chain switching with automatic database separation
 - **Phoenix PubSub integration** - Real-time event broadcasting
 
@@ -104,6 +105,11 @@ config :hyperliquid,
   enable_db: false,
   enable_web: false,
   autostart_cache: true,
+
+  # Local node (for --serve-info and --serve-eth-rpc)
+  enable_node_info: false,
+  enable_node_rpc: false,
+  node_url: "http://localhost:3001",
 
   # Debug logging
   debug: false,
@@ -600,6 +606,71 @@ config: [
     private_key: "YOUR_TESTNET_KEY"
   ]
 ])
+```
+
+## Local Node
+
+When running a Hyperliquid node with `--serve-info` and/or `--serve-eth-rpc`, the `Hyperliquid.Node` module provides low-latency access without rate limits.
+
+### Configuration
+
+Info and RPC endpoints can be enabled independently:
+
+```elixir
+config :hyperliquid,
+  node_url: "http://localhost:3001",
+  enable_node_info: true,  # enables Node info convenience functions
+  enable_node_rpc: true    # registers :node named RPC at startup
+```
+
+### Info Endpoints
+
+Convenience functions are generated for all documented local info endpoints, with automatic struct parsing:
+
+```elixir
+alias Hyperliquid.Node
+
+# Parsed struct responses (same types as the public API)
+{:ok, meta} = Node.meta()
+{:ok, state} = Node.clearinghouse_state("0x...")
+{:ok, orders} = Node.open_orders("0x...")
+{:ok, status} = Node.exchange_status()
+
+# Generic fallback for any info request (returns raw map)
+{:ok, data} = Node.info_request(%{type: "someEndpoint", user: "0x..."})
+
+# Health check
+{:ok, _} = Node.ping()
+```
+
+### File Snapshots
+
+The local info server supports `fileSnapshot` requests that write large data to files on the node's filesystem:
+
+```elixir
+# Generic file snapshot
+Node.file_snapshot(%{type: "referrerStates"}, "/tmp/out.json")
+
+# Convenience helpers
+Node.referrer_states_snapshot("/tmp/referrer.json")
+Node.l4_snapshots("/tmp/l4.json", include_users: true, include_trigger_orders: true)
+
+# Include block height in output
+Node.file_snapshot(%{type: "referrerStates"}, "/tmp/out.json", include_height: true)
+```
+
+### EVM RPC
+
+When `enable_node_rpc: true`, a `:node` named RPC is registered at startup. Use it through the existing RPC modules or the Node helpers:
+
+```elixir
+# Via existing RPC modules
+alias Hyperliquid.Rpc.Eth
+Eth.block_number(rpc_name: :node)
+
+# Via Node helpers
+Node.rpc_call("eth_blockNumber")
+Node.rpc_call("eth_getBalance", ["0x...", "latest"])
 ```
 
 ## Explorer API

--- a/README.md
+++ b/README.md
@@ -612,6 +612,42 @@ config: [
 
 When running a Hyperliquid node with `--serve-info` and/or `--serve-eth-rpc`, the `Hyperliquid.Node` module provides low-latency access without rate limits.
 
+### Running the node
+
+Start `hl-node` with the flags for whichever surfaces you want. Both are served
+on the same port (3001 by default):
+
+```bash
+# Info server only
+./hl-node --serve-info
+
+# Info server + EVM JSON-RPC
+./hl-node --serve-info --serve-eth-rpc
+```
+
+Confirm each is up before pointing the client at it:
+
+```bash
+# Info server
+curl -s -X POST http://localhost:3001/info \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"exchangeStatus"}'
+# => {"specialStatuses":null,"time":1786299106680}
+
+# EVM RPC
+curl -s -X POST http://localhost:3001/evm \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+# => {"jsonrpc":"2.0","id":1,"result":"0x3e7"}
+```
+
+If the node runs on another host, tunnel the port rather than exposing it —
+the info server binds `0.0.0.0` and is unauthenticated:
+
+```bash
+ssh -N -L 3001:localhost:3001 your-node-host
+```
+
 ### Configuration
 
 Info and RPC endpoints can be enabled independently:
@@ -636,6 +672,8 @@ alias Hyperliquid.Node
 {:ok, metas} = Node.all_perp_metas()
 {:ok, reserves} = Node.all_borrow_lend_reserve_states()
 {:ok, spot} = Node.spot_meta()
+{:ok, auction} = Node.gossip_priority_auction_status()
+{:ok, ann} = Node.perp_concise_annotations()
 
 # User-param endpoints
 {:ok, state} = Node.clearinghouse_state("0x...")
@@ -644,10 +682,15 @@ alias Hyperliquid.Node
 {:ok, accounts} = Node.sub_accounts2("0x...")
 {:ok, abstraction} = Node.user_dex_abstraction("0x...")
 
+# HIP-4 prediction markets
+{:ok, meta} = Node.outcome_meta()
+{:ok, templates} = Node.outcome_templates()
+{:ok, settled} = Node.settled_outcome(1)
+
 # Other single-param endpoints
 {:ok, table} = Node.margin_table(56)
-{:ok, info} = Node.aligned_quote_token_info(0)
 {:ok, limits} = Node.perp_dex_limits("some_dex")
+{:ok, status} = Node.perp_dex_status("")
 {:ok, reserve} = Node.borrow_lend_reserve_state(0)
 {:ok, ann} = Node.perp_annotation("BTC")
 
@@ -665,12 +708,13 @@ alias Hyperliquid.Node
 ```
 
 <details>
-<summary>Supported local node info endpoints (42 total)</summary>
+<summary>Supported local node info endpoints (48 verified)</summary>
 
 **No-param:** `meta`*, `spotMeta`, `allPerpMetas`, `allBorrowLendReserveStates`,
 `exchangeStatus`, `liquidatable`, `vaultSummaries`, `leadingVaults`, `perpDexs`,
 `perpCategories`, `perpDeployAuctionStatus`, `perpsAtOpenInterestCap`*, `spotDeployState`,
-`spotPairDeployAuctionStatus`, `validatorL1Votes`, `maxMarketOrderNtls`
+`spotPairDeployAuctionStatus`, `validatorL1Votes`, `maxMarketOrderNtls`,
+`gossipPriorityAuctionStatus`, `perpConciseAnnotations`, `outcomeMeta`, `outcomeTemplates`
 
 **User-param:** `clearinghouseState`*, `spotClearinghouseState`, `openOrders`*,
 `frontendOpenOrders`*, `extraAgents`, `subAccounts`, `subAccounts2`, `userFees`,
@@ -680,18 +724,31 @@ alias Hyperliquid.Node
 
 **User+coin:** `activeAssetData`
 
-**Other params:** `marginTable` (id), `alignedQuoteTokenInfo` (token),
-`borrowLendReserveState` (token), `perpAnnotation` (coin), `perpDexLimits` (dex)
+**Other params:** `marginTable` (id), `borrowLendReserveState` (token, **integer**),
+`perpAnnotation` (coin), `perpDexLimits` (dex), `perpDexStatus` (dex),
+`settledOutcome` (outcome)
 
 \* Supports optional `dex:` keyword arg
 
-**Not supported on local node:** `allMids`, `metaAndAssetCtxs`, `spotMetaAndAssetCtxs`,
-`predictedFundings`, `l2Book`, `recentTrades`, `candleSnapshot`, `fundingHistory`,
-`userFills`, `userFillsByTime`, `userFunding`, `userBorrowLendInterest`,
-`userNonFundingLedgerUpdates`, `historicalOrders`, `orderStatus`, `perpDexStatus`,
-`vaultDetails`, `tokenDetails`, `validatorSummaries`, `gossipRootIps`,
-`portfolio`, `referral`, `isVip`, `legalCheck`, `preTransferCheck`, `twapHistory`,
-`delegatorHistory`, `delegatorRewards`, `userTwapSliceFills`, `userTwapSliceFillsByTime`
+**Not served by the node.** These fall back to the public API. The node holds
+state, not indexed history or aggregated market data, which is what this split
+reflects:
+
+`allMids`, `metaAndAssetCtxs`, `spotMetaAndAssetCtxs`, `predictedFundings`,
+`l2Book`, `recentTrades`, `candleSnapshot`, `fundingHistory`, `userFills`,
+`userFillsByTime`, `userFunding`, `userBorrowLendInterest`,
+`userNonFundingLedgerUpdates`, `historicalOrders`, `orderStatus`, `vaultDetails`,
+`tokenDetails`, `validatorSummaries`, `gossipRootIps`, `usdcRouting`, `portfolio`,
+`referral`, `isVip`, `legalCheck`, `preTransferCheck`, `twapHistory`,
+`delegatorHistory`, `delegatorRewards`, `userTwapSliceFills`,
+`userTwapSliceFillsByTime`, `alignedQuoteTokenInfo`
+
+`Node.aligned_quote_token_info/1` is still generated, but the node rejects it —
+probed with both string and integer token values.
+
+Verified by probing a live node on 2026-08-09. The node returns the same
+deserialization error for an unknown request type and a malformed one, so a
+type absent here may simply need a different request shape.
 
 </details>
 

--- a/lib/hyperliquid/application.ex
+++ b/lib/hyperliquid/application.ex
@@ -42,7 +42,16 @@ defmodule Hyperliquid.Application do
           []
         end ++
         [
-          {Hyperliquid.Rpc.Registry, [rpcs: Config.named_rpcs()]},
+          {Hyperliquid.Rpc.Registry,
+           [
+             rpcs:
+               Config.named_rpcs()
+               |> then(fn rpcs ->
+                 if Config.node_rpc_enabled?(),
+                   do: Map.put(rpcs, :node, "#{Config.node_url()}/evm"),
+                   else: rpcs
+               end)
+           ]},
           Hyperliquid.WebSocket.Supervisor
         ]
 

--- a/lib/hyperliquid/config.ex
+++ b/lib/hyperliquid/config.ex
@@ -453,6 +453,67 @@ defmodule Hyperliquid.Config do
   end
 
   @doc """
+  Returns the maximum number of simultaneous WebSocket connections.
+
+  Hyperliquid enforces a limit of 10 concurrent WebSocket connections per client.
+  The manager will return `{:error, :connection_limit_exceeded}` when this is reached.
+
+  ## Configuration
+
+      config :hyperliquid,
+        ws_max_connections: 10
+  """
+  def ws_max_connections do
+    Application.get_env(:hyperliquid, :ws_max_connections, 10)
+  end
+
+  @doc """
+  Returns the maximum number of new WebSocket connections allowed per minute.
+
+  Hyperliquid enforces a rate limit of 30 new connections per minute per client.
+  The manager will return `{:error, :connection_rate_exceeded}` when this is reached.
+
+  ## Configuration
+
+      config :hyperliquid,
+        ws_max_connections_per_minute: 30
+  """
+  def ws_max_connections_per_minute do
+    Application.get_env(:hyperliquid, :ws_max_connections_per_minute, 30)
+  end
+
+  @doc """
+  Returns the maximum number of simultaneous WebSocket subscriptions.
+
+  Hyperliquid enforces a limit of 1000 concurrent subscriptions per client.
+  The manager will return `{:error, :subscription_limit_exceeded}` when this is reached.
+
+  ## Configuration
+
+      config :hyperliquid,
+        ws_max_subscriptions: 1000
+  """
+  def ws_max_subscriptions do
+    Application.get_env(:hyperliquid, :ws_max_subscriptions, 1000)
+  end
+
+  @doc """
+  Returns the maximum number of unique users allowed across user-specific WebSocket subscriptions.
+
+  Hyperliquid enforces a limit of 10 unique users across all user-grouped subscriptions
+  (e.g., userFills, userFundings, orderUpdates). The manager will return
+  `{:error, :user_limit_exceeded}` when subscribing would exceed this limit.
+
+  ## Configuration
+
+      config :hyperliquid,
+        ws_max_users: 10
+  """
+  def ws_max_users do
+    Application.get_env(:hyperliquid, :ws_max_users, 10)
+  end
+
+  @doc """
   Returns the URL for a local Hyperliquid node.
 
   Local nodes can serve EVM JSON-RPC (`/evm`) and Info API (`/info`) endpoints

--- a/lib/hyperliquid/config.ex
+++ b/lib/hyperliquid/config.ex
@@ -451,4 +451,56 @@ defmodule Hyperliquid.Config do
   def cache_janitor_interval do
     Application.get_env(:hyperliquid, :cache_janitor_interval, 60_000)
   end
+
+  @doc """
+  Returns the URL for a local Hyperliquid node.
+
+  Local nodes can serve EVM JSON-RPC (`/evm`) and Info API (`/info`) endpoints
+  when started with `--serve-eth-rpc` and `--serve-info` flags.
+
+  Defaults to `http://localhost:3001`.
+
+  ## Configuration
+
+      config :hyperliquid,
+        node_url: "http://localhost:3001"
+  """
+  def node_url do
+    Application.get_env(:hyperliquid, :node_url, "http://localhost:3001")
+  end
+
+  @doc """
+  Returns whether the local node EVM RPC is enabled.
+
+  When true, the application registers a `:node` named RPC pointing to
+  `node_url()/evm` in the RPC Registry at startup. This allows using
+  `rpc_name: :node` in RPC calls.
+
+  Defaults to `false`.
+
+  ## Configuration
+
+      config :hyperliquid,
+        enable_node_rpc: true
+  """
+  def node_rpc_enabled? do
+    Application.get_env(:hyperliquid, :enable_node_rpc, false) == true
+  end
+
+  @doc """
+  Returns whether the local node Info API is enabled.
+
+  When true, `Hyperliquid.Node` convenience functions will send requests
+  to `node_url()/info`. The node must be running with `--serve-info`.
+
+  Defaults to `false`.
+
+  ## Configuration
+
+      config :hyperliquid,
+        enable_node_info: true
+  """
+  def node_info_enabled? do
+    Application.get_env(:hyperliquid, :enable_node_info, false) == true
+  end
 end

--- a/lib/hyperliquid/node.ex
+++ b/lib/hyperliquid/node.ex
@@ -8,10 +8,10 @@ defmodule Hyperliquid.Node do
 
   ## Info Endpoints
 
-  Convenience functions are generated for the documented subset of info requests
-  supported by the local info server. Each function sends the request to the
-  node's `/info` endpoint and parses the response using the corresponding
-  endpoint module when available.
+  Convenience functions are generated for the info requests verified to work on
+  the local info server. Each function sends the request to the node's `/info`
+  endpoint and parses the response using the corresponding endpoint module when
+  available.
 
       # Documented endpoints with parsed struct responses
       Hyperliquid.Node.meta()
@@ -53,52 +53,98 @@ defmodule Hyperliquid.Node do
   alias Hyperliquid.Transport.Http
   alias Hyperliquid.Transport.Rpc
 
-  # Documented supported endpoints on the local info server.
-  # Format: {function_name, request_type, endpoint_module, params}
-  # params: [] = no params, [:user] = required user param, etc.
+  # Supported endpoints on the local info server.
+  # Format: {function_name, request_type, endpoint_module, required_params, optional_params}
+  # required_params: [] = no params, [:user] = required user param, etc.
+  # optional_params: [] = none, [:dex] = optional dex keyword arg, etc.
+  #
+  # Endpoints with optional_params get an extra `opts \\ []` argument:
+  #   Node.meta(dex: "some_dex")
+  #   Node.clearinghouse_state("0x...", dex: "some_dex")
   @supported_endpoints [
-    {:meta, "meta", Hyperliquid.Api.Info.Meta, []},
-    {:spot_meta, "spotMeta", Hyperliquid.Api.Info.SpotMeta, []},
-    {:clearinghouse_state, "clearinghouseState", Hyperliquid.Api.Info.ClearinghouseState, [:user]},
-    {:spot_clearinghouse_state, "spotClearinghouseState",
-     Hyperliquid.Api.Info.SpotClearinghouseState, [:user]},
-    {:open_orders, "openOrders", Hyperliquid.Api.Info.OpenOrders, [:user]},
-    {:exchange_status, "exchangeStatus", Hyperliquid.Api.Info.ExchangeStatus, []},
-    {:frontend_open_orders, "frontendOpenOrders", Hyperliquid.Api.Info.FrontendOpenOrders,
-     [:user]},
-    {:liquidatable, "liquidatable", Hyperliquid.Api.Info.Liquidatable, []},
-    {:active_asset_data, "activeAssetData", Hyperliquid.Api.Info.ActiveAssetData, [:user, :coin]},
-    {:max_market_order_ntls, "maxMarketOrderNtls", Hyperliquid.Api.Info.MaxMarketOrderNtls,
-     [:user]},
-    {:vault_summaries, "vaultSummaries", Hyperliquid.Api.Info.VaultSummaries, []},
-    {:user_vault_equities, "userVaultEquities", Hyperliquid.Api.Info.UserVaultEquities, [:user]},
-    {:leading_vaults, "leadingVaults", Hyperliquid.Api.Info.LeadingVaults, []},
-    {:extra_agents, "extraAgents", Hyperliquid.Api.Info.ExtraAgents, [:user]},
-    {:sub_accounts, "subAccounts", Hyperliquid.Api.Info.SubAccounts, [:user]},
-    {:user_fees, "userFees", Hyperliquid.Api.Info.UserFees, [:user]},
-    {:user_rate_limit, "userRateLimit", Hyperliquid.Api.Info.UserRateLimit, [:user]},
-    {:spot_deploy_state, "spotDeployState", Hyperliquid.Api.Info.SpotDeployState, []},
+    # ---- No-param endpoints ----
+    {:meta, "meta", Hyperliquid.Api.Info.Meta, [], [:dex]},
+    {:spot_meta, "spotMeta", Hyperliquid.Api.Info.SpotMeta, [], []},
+    {:all_perp_metas, "allPerpMetas", Hyperliquid.Api.Info.AllPerpMetas, [], []},
+    {:all_borrow_lend_reserve_states, "allBorrowLendReserveStates",
+     Hyperliquid.Api.Info.AllBorrowLendReserveStates, [], []},
+    {:exchange_status, "exchangeStatus", Hyperliquid.Api.Info.ExchangeStatus, [], []},
+    {:liquidatable, "liquidatable", Hyperliquid.Api.Info.Liquidatable, [], []},
+    {:vault_summaries, "vaultSummaries", Hyperliquid.Api.Info.VaultSummaries, [], []},
+    {:leading_vaults, "leadingVaults", Hyperliquid.Api.Info.LeadingVaults, [], []},
+    {:perp_dexs, "perpDexs", Hyperliquid.Api.Info.PerpDexs, [], []},
+    {:perp_categories, "perpCategories", Hyperliquid.Api.Info.PerpCategories, [], []},
     {:perp_deploy_auction_status, "perpDeployAuctionStatus",
-     Hyperliquid.Api.Info.PerpDeployAuctionStatus, []},
-    {:delegations, "delegations", Hyperliquid.Api.Info.Delegations, [:user]},
-    {:delegator_summary, "delegatorSummary", Hyperliquid.Api.Info.DelegatorSummary, [:user]},
-    {:max_builder_fee, "maxBuilderFee", Hyperliquid.Api.Info.MaxBuilderFee, [:user]},
-    {:user_to_multi_sig_signers, "userToMultiSigSigners",
-     Hyperliquid.Api.Info.UserToMultiSigSigners, [:user]},
-    {:user_role, "userRole", Hyperliquid.Api.Info.UserRole, [:user]},
+     Hyperliquid.Api.Info.PerpDeployAuctionStatus, [], []},
     {:perps_at_open_interest_cap, "perpsAtOpenInterestCap",
-     Hyperliquid.Api.Info.PerpsAtOpenInterestCap, []},
-    {:validator_l1_votes, "validatorL1Votes", Hyperliquid.Api.Info.ValidatorL1Votes, []},
-    {:margin_table, "marginTable", Hyperliquid.Api.Info.MarginTable, []},
-    {:perp_dexs, "perpDexs", Hyperliquid.Api.Info.PerpDexs, []},
+     Hyperliquid.Api.Info.PerpsAtOpenInterestCap, [], [:dex]},
+    {:spot_deploy_state, "spotDeployState", Hyperliquid.Api.Info.SpotDeployState, [], []},
+    {:spot_pair_deploy_auction_status, "spotPairDeployAuctionStatus",
+     Hyperliquid.Api.Info.SpotPairDeployAuctionStatus, [], []},
+    {:validator_l1_votes, "validatorL1Votes", Hyperliquid.Api.Info.ValidatorL1Votes, [], []},
+    # ---- User-param endpoints ----
+    {:max_market_order_ntls, "maxMarketOrderNtls", Hyperliquid.Api.Info.MaxMarketOrderNtls,
+     [:user], []},
+    {:clearinghouse_state, "clearinghouseState", Hyperliquid.Api.Info.ClearinghouseState, [:user],
+     [:dex]},
+    {:spot_clearinghouse_state, "spotClearinghouseState",
+     Hyperliquid.Api.Info.SpotClearinghouseState, [:user], []},
+    {:open_orders, "openOrders", Hyperliquid.Api.Info.OpenOrders, [:user], [:dex]},
+    {:frontend_open_orders, "frontendOpenOrders", Hyperliquid.Api.Info.FrontendOpenOrders,
+     [:user], [:dex]},
+    {:extra_agents, "extraAgents", Hyperliquid.Api.Info.ExtraAgents, [:user], []},
+    {:sub_accounts, "subAccounts", Hyperliquid.Api.Info.SubAccounts, [:user], []},
+    {:sub_accounts2, "subAccounts2", Hyperliquid.Api.Info.SubAccounts2, [:user], []},
+    {:user_fees, "userFees", Hyperliquid.Api.Info.UserFees, [:user], []},
+    {:user_rate_limit, "userRateLimit", Hyperliquid.Api.Info.UserRateLimit, [:user], []},
+    {:user_vault_equities, "userVaultEquities", Hyperliquid.Api.Info.UserVaultEquities, [:user],
+     []},
+    {:user_dex_abstraction, "userDexAbstraction", Hyperliquid.Api.Info.UserDexAbstraction,
+     [:user], []},
+    {:user_to_multi_sig_signers, "userToMultiSigSigners",
+     Hyperliquid.Api.Info.UserToMultiSigSigners, [:user], []},
+    {:user_role, "userRole", Hyperliquid.Api.Info.UserRole, [:user], []},
+    {:user_abstraction, "userAbstraction", Hyperliquid.Api.Info.UserAbstraction, [:user], []},
+    {:approved_builders, "approvedBuilders", Hyperliquid.Api.Info.ApprovedBuilders, [:user], []},
+    {:borrow_lend_user_state, "borrowLendUserState", Hyperliquid.Api.Info.BorrowLendUserState,
+     [:user], []},
+    {:delegations, "delegations", Hyperliquid.Api.Info.Delegations, [:user], []},
+    {:delegator_summary, "delegatorSummary", Hyperliquid.Api.Info.DelegatorSummary, [:user], []},
+    {:max_builder_fee, "maxBuilderFee", Hyperliquid.Api.Info.MaxBuilderFee, [:user], []},
+    # ---- User+coin endpoints ----
+    {:active_asset_data, "activeAssetData", Hyperliquid.Api.Info.ActiveAssetData, [:user, :coin],
+     []},
+    # ---- Other single-param endpoints ----
+    {:margin_table, "marginTable", Hyperliquid.Api.Info.MarginTable, [:id], []},
+    {:aligned_quote_token_info, "alignedQuoteTokenInfo",
+     Hyperliquid.Api.Info.AlignedQuoteTokenInfo, [:token], []},
+    {:borrow_lend_reserve_state, "borrowLendReserveState",
+     Hyperliquid.Api.Info.BorrowLendReserveState, [:token], []},
+    {:perp_annotation, "perpAnnotation", Hyperliquid.Api.Info.PerpAnnotation, [:coin], []},
+    {:perp_dex_limits, "perpDexLimits", Hyperliquid.Api.Info.PerpDexLimits, [:dex], []},
+    # ---- Raw (no endpoint module) ----
     # webData2 doesn't compute assetCtxs on node, no dedicated module
-    {:web_data2, "webData2", nil, [:user]}
+    {:web_data2, "webData2", nil, [:user], []}
   ]
 
+  # Builds a payload from a base map + optional keyword args.
+  # Only keys present in `optional_keys` are included; nil values are dropped.
+  defp apply_opts(base, _optional_keys, []), do: base
+
+  defp apply_opts(base, optional_keys, opts) do
+    Enum.reduce(optional_keys, base, fn key, acc ->
+      case Keyword.get(opts, key) do
+        nil -> acc
+        val -> Map.put(acc, key, val)
+      end
+    end)
+  end
+
   # Generate convenience functions from the endpoint list
-  for {func_name, request_type, endpoint_mod, params} <- @supported_endpoints do
-    case params do
-      [] ->
+  for {func_name, request_type, endpoint_mod, required, optional} <- @supported_endpoints do
+    case {required, optional} do
+      # No required params, no optional params
+      {[], []} ->
         @doc "Fetch `#{request_type}` from the local node."
         def unquote(func_name)() do
           with {:ok, data} <- Http.node_info_request(%{type: unquote(request_type)}) do
@@ -106,7 +152,19 @@ defmodule Hyperliquid.Node do
           end
         end
 
-      [:user] ->
+      # No required params, with optional params
+      {[], _} ->
+        @doc "Fetch `#{request_type}` from the local node. Accepts `#{inspect(optional)}` as optional keyword args."
+        def unquote(func_name)(opts \\ []) do
+          payload = apply_opts(%{type: unquote(request_type)}, unquote(optional), opts)
+
+          with {:ok, data} <- Http.node_info_request(payload) do
+            maybe_parse(unquote(endpoint_mod), data)
+          end
+        end
+
+      # User required, no optional params
+      {[:user], []} ->
         @doc "Fetch `#{request_type}` for the given user from the local node."
         def unquote(func_name)(user) do
           with {:ok, data} <-
@@ -115,7 +173,20 @@ defmodule Hyperliquid.Node do
           end
         end
 
-      [:user, :coin] ->
+      # User required, with optional params
+      {[:user], _} ->
+        @doc "Fetch `#{request_type}` for the given user from the local node. Accepts `#{inspect(optional)}` as optional keyword args."
+        def unquote(func_name)(user, opts \\ []) do
+          payload =
+            apply_opts(%{type: unquote(request_type), user: user}, unquote(optional), opts)
+
+          with {:ok, data} <- Http.node_info_request(payload) do
+            maybe_parse(unquote(endpoint_mod), data)
+          end
+        end
+
+      # User + coin required
+      {[:user, :coin], _} ->
         @doc "Fetch `#{request_type}` for the given user and coin from the local node."
         def unquote(func_name)(user, coin) do
           with {:ok, data} <-
@@ -124,6 +195,40 @@ defmodule Hyperliquid.Node do
                    user: user,
                    coin: coin
                  }) do
+            maybe_parse(unquote(endpoint_mod), data)
+          end
+        end
+
+      # Single non-user param, no optional params
+      {[param], []} ->
+        @doc "Fetch `#{request_type}` for the given #{param} from the local node."
+        def unquote(func_name)(unquote(Macro.var(param, nil))) do
+          payload =
+            Map.put(
+              %{type: unquote(request_type)},
+              unquote(param),
+              unquote(Macro.var(param, nil))
+            )
+
+          with {:ok, data} <- Http.node_info_request(payload) do
+            maybe_parse(unquote(endpoint_mod), data)
+          end
+        end
+
+      # Single non-user param, with optional params
+      {[param], _} ->
+        @doc "Fetch `#{request_type}` for the given #{param} from the local node. Accepts `#{inspect(optional)}` as optional keyword args."
+        def unquote(func_name)(unquote(Macro.var(param, nil)), opts \\ []) do
+          base =
+            Map.put(
+              %{type: unquote(request_type)},
+              unquote(param),
+              unquote(Macro.var(param, nil))
+            )
+
+          payload = apply_opts(base, unquote(optional), opts)
+
+          with {:ok, data} <- Http.node_info_request(payload) do
             maybe_parse(unquote(endpoint_mod), data)
           end
         end

--- a/lib/hyperliquid/node.ex
+++ b/lib/hyperliquid/node.ex
@@ -1,0 +1,246 @@
+defmodule Hyperliquid.Node do
+  @moduledoc """
+  Client for interacting with a local Hyperliquid node.
+
+  Local nodes can serve EVM JSON-RPC (`/evm`) and Info API (`/info`) endpoints
+  when started with `--serve-eth-rpc` and `--serve-info` flags. This gives lower
+  latency, no rate limits, and reduced trust assumptions.
+
+  ## Info Endpoints
+
+  Convenience functions are generated for the documented subset of info requests
+  supported by the local info server. Each function sends the request to the
+  node's `/info` endpoint and parses the response using the corresponding
+  endpoint module when available.
+
+      # Documented endpoints with parsed struct responses
+      Hyperliquid.Node.meta()
+      Hyperliquid.Node.clearinghouse_state("0x...")
+
+      # Generic fallback for any info request (returns raw snake_cased map)
+      Hyperliquid.Node.info_request(%{type: "someEndpoint"})
+
+  ## File Snapshots
+
+  The local info server supports `fileSnapshot` requests that write large
+  snapshot data to files on the node's filesystem.
+
+      Hyperliquid.Node.file_snapshot(%{type: "referrerStates"}, "/tmp/out.json")
+      Hyperliquid.Node.referrer_states_snapshot("/tmp/out.json")
+      Hyperliquid.Node.l4_snapshots("/tmp/out.json")
+
+  ## EVM RPC
+
+  When `enable_node_rpc: true` is configured, a `:node` named RPC is registered
+  at startup pointing to `node_url/evm`. You can use it directly:
+
+      Hyperliquid.Rpc.Eth.block_number(rpc_name: :node)
+
+  Or through the convenience helpers:
+
+      Hyperliquid.Node.rpc_call("eth_blockNumber")
+
+  ## Configuration
+
+  Info and RPC can be enabled independently:
+
+      config :hyperliquid,
+        node_url: "http://localhost:3001",
+        enable_node_info: true,  # enables Node info convenience functions
+        enable_node_rpc: true    # registers :node named RPC at startup
+  """
+
+  alias Hyperliquid.Transport.Http
+  alias Hyperliquid.Transport.Rpc
+
+  # Documented supported endpoints on the local info server.
+  # Format: {function_name, request_type, endpoint_module, params}
+  # params: [] = no params, [:user] = required user param, etc.
+  @supported_endpoints [
+    {:meta, "meta", Hyperliquid.Api.Info.Meta, []},
+    {:spot_meta, "spotMeta", Hyperliquid.Api.Info.SpotMeta, []},
+    {:clearinghouse_state, "clearinghouseState", Hyperliquid.Api.Info.ClearinghouseState, [:user]},
+    {:spot_clearinghouse_state, "spotClearinghouseState",
+     Hyperliquid.Api.Info.SpotClearinghouseState, [:user]},
+    {:open_orders, "openOrders", Hyperliquid.Api.Info.OpenOrders, [:user]},
+    {:exchange_status, "exchangeStatus", Hyperliquid.Api.Info.ExchangeStatus, []},
+    {:frontend_open_orders, "frontendOpenOrders", Hyperliquid.Api.Info.FrontendOpenOrders,
+     [:user]},
+    {:liquidatable, "liquidatable", Hyperliquid.Api.Info.Liquidatable, []},
+    {:active_asset_data, "activeAssetData", Hyperliquid.Api.Info.ActiveAssetData, [:user, :coin]},
+    {:max_market_order_ntls, "maxMarketOrderNtls", Hyperliquid.Api.Info.MaxMarketOrderNtls,
+     [:user]},
+    {:vault_summaries, "vaultSummaries", Hyperliquid.Api.Info.VaultSummaries, []},
+    {:user_vault_equities, "userVaultEquities", Hyperliquid.Api.Info.UserVaultEquities, [:user]},
+    {:leading_vaults, "leadingVaults", Hyperliquid.Api.Info.LeadingVaults, []},
+    {:extra_agents, "extraAgents", Hyperliquid.Api.Info.ExtraAgents, [:user]},
+    {:sub_accounts, "subAccounts", Hyperliquid.Api.Info.SubAccounts, [:user]},
+    {:user_fees, "userFees", Hyperliquid.Api.Info.UserFees, [:user]},
+    {:user_rate_limit, "userRateLimit", Hyperliquid.Api.Info.UserRateLimit, [:user]},
+    {:spot_deploy_state, "spotDeployState", Hyperliquid.Api.Info.SpotDeployState, []},
+    {:perp_deploy_auction_status, "perpDeployAuctionStatus",
+     Hyperliquid.Api.Info.PerpDeployAuctionStatus, []},
+    {:delegations, "delegations", Hyperliquid.Api.Info.Delegations, [:user]},
+    {:delegator_summary, "delegatorSummary", Hyperliquid.Api.Info.DelegatorSummary, [:user]},
+    {:max_builder_fee, "maxBuilderFee", Hyperliquid.Api.Info.MaxBuilderFee, [:user]},
+    {:user_to_multi_sig_signers, "userToMultiSigSigners",
+     Hyperliquid.Api.Info.UserToMultiSigSigners, [:user]},
+    {:user_role, "userRole", Hyperliquid.Api.Info.UserRole, [:user]},
+    {:perps_at_open_interest_cap, "perpsAtOpenInterestCap",
+     Hyperliquid.Api.Info.PerpsAtOpenInterestCap, []},
+    {:validator_l1_votes, "validatorL1Votes", Hyperliquid.Api.Info.ValidatorL1Votes, []},
+    {:margin_table, "marginTable", Hyperliquid.Api.Info.MarginTable, []},
+    {:perp_dexs, "perpDexs", Hyperliquid.Api.Info.PerpDexs, []},
+    # webData2 doesn't compute assetCtxs on node, no dedicated module
+    {:web_data2, "webData2", nil, [:user]}
+  ]
+
+  # Generate convenience functions from the endpoint list
+  for {func_name, request_type, endpoint_mod, params} <- @supported_endpoints do
+    case params do
+      [] ->
+        @doc "Fetch `#{request_type}` from the local node."
+        def unquote(func_name)() do
+          with {:ok, data} <- Http.node_info_request(%{type: unquote(request_type)}) do
+            maybe_parse(unquote(endpoint_mod), data)
+          end
+        end
+
+      [:user] ->
+        @doc "Fetch `#{request_type}` for the given user from the local node."
+        def unquote(func_name)(user) do
+          with {:ok, data} <-
+                 Http.node_info_request(%{type: unquote(request_type), user: user}) do
+            maybe_parse(unquote(endpoint_mod), data)
+          end
+        end
+
+      [:user, :coin] ->
+        @doc "Fetch `#{request_type}` for the given user and coin from the local node."
+        def unquote(func_name)(user, coin) do
+          with {:ok, data} <-
+                 Http.node_info_request(%{
+                   type: unquote(request_type),
+                   user: user,
+                   coin: coin
+                 }) do
+            maybe_parse(unquote(endpoint_mod), data)
+          end
+        end
+    end
+  end
+
+  @doc """
+  Send any info request to the local node.
+
+  This is a generic fallback that accepts any payload. Use this for
+  undocumented endpoints or when you need full control over the request.
+
+  ## Examples
+
+      Hyperliquid.Node.info_request(%{type: "someEndpoint"})
+      Hyperliquid.Node.info_request(%{type: "clearinghouseState", user: "0x..."})
+  """
+  def info_request(payload, opts \\ []) do
+    Http.node_info_request(payload, opts)
+  end
+
+  # ===================== File Snapshots =====================
+
+  @doc """
+  Send a `fileSnapshot` request to the local node.
+
+  File snapshot requests write large data sets to a file on the node's filesystem
+  rather than returning them in the HTTP response.
+
+  ## Parameters
+    - `request`: The inner request map (e.g., `%{type: "referrerStates"}`)
+    - `out_path`: Absolute path on the node where the snapshot file will be written
+    - `opts`:
+      - `:include_height` - Whether to include block height in output (default: `false`)
+
+  ## Examples
+
+      Hyperliquid.Node.file_snapshot(%{type: "referrerStates"}, "/tmp/out.json")
+  """
+  def file_snapshot(request, out_path, opts \\ []) do
+    payload = %{
+      type: "fileSnapshot",
+      request: request,
+      outPath: out_path,
+      includeHeightInOutput: Keyword.get(opts, :include_height, false)
+    }
+
+    Http.node_info_request(payload)
+  end
+
+  @doc """
+  Write a referrer states snapshot to a file on the node.
+
+  ## Parameters
+    - `out_path`: File path on the node
+    - `opts`: See `file_snapshot/3`
+  """
+  def referrer_states_snapshot(out_path, opts \\ []),
+    do: file_snapshot(%{type: "referrerStates"}, out_path, opts)
+
+  @doc """
+  Write L4 snapshots to a file on the node.
+
+  ## Parameters
+    - `out_path`: File path on the node
+    - `opts`:
+      - `:include_users` - Include user data (default: `true`)
+      - `:include_trigger_orders` - Include trigger orders (default: `true`)
+      - `:include_height` - Include block height in output (default: `false`)
+  """
+  def l4_snapshots(out_path, opts \\ []) do
+    file_snapshot(
+      %{
+        type: "l4Snapshots",
+        includeUsers: Keyword.get(opts, :include_users, true),
+        includeTriggerOrders: Keyword.get(opts, :include_trigger_orders, true)
+      },
+      out_path,
+      opts
+    )
+  end
+
+  # ===================== EVM RPC =====================
+
+  @doc """
+  Make a JSON-RPC call to the node's EVM endpoint.
+
+  Requires `enable_node_rpc: true` in config so the `:node` named RPC is registered.
+
+  ## Examples
+
+      Hyperliquid.Node.rpc_call("eth_blockNumber")
+      Hyperliquid.Node.rpc_call("eth_getBalance", ["0x...", "latest"])
+  """
+  def rpc_call(method, params \\ []), do: Rpc.call(method, params, rpc_name: :node)
+
+  @doc """
+  Like `rpc_call/2` but raises on error.
+  """
+  def rpc_call!(method, params \\ []), do: Rpc.call!(method, params, rpc_name: :node)
+
+  # ===================== Health =====================
+
+  @doc """
+  Ping the local node by requesting exchange status.
+
+  Returns `{:ok, data}` if the node is reachable, `{:error, reason}` otherwise.
+  """
+  def ping, do: Http.node_info_request(%{type: "exchangeStatus"})
+
+  # ===================== Private =====================
+
+  defp maybe_parse(nil, data), do: {:ok, data}
+
+  defp maybe_parse(mod, data) do
+    Code.ensure_loaded!(mod)
+    data = if function_exported?(mod, :preprocess, 1), do: mod.preprocess(data), else: data
+    mod.parse_response(data)
+  end
+end

--- a/lib/hyperliquid/node.ex
+++ b/lib/hyperliquid/node.ex
@@ -82,6 +82,13 @@ defmodule Hyperliquid.Node do
     {:spot_pair_deploy_auction_status, "spotPairDeployAuctionStatus",
      Hyperliquid.Api.Info.SpotPairDeployAuctionStatus, [], []},
     {:validator_l1_votes, "validatorL1Votes", Hyperliquid.Api.Info.ValidatorL1Votes, [], []},
+    {:gossip_priority_auction_status, "gossipPriorityAuctionStatus",
+     Hyperliquid.Api.Info.GossipPriorityAuctionStatus, [], []},
+    {:perp_concise_annotations, "perpConciseAnnotations",
+     Hyperliquid.Api.Info.PerpConciseAnnotations, [], []},
+    # ---- HIP-4 prediction markets ----
+    {:outcome_meta, "outcomeMeta", Hyperliquid.Api.Info.OutcomeMeta, [], []},
+    {:outcome_templates, "outcomeTemplates", Hyperliquid.Api.Info.OutcomeTemplates, [], []},
     # ---- User-param endpoints ----
     {:max_market_order_ntls, "maxMarketOrderNtls", Hyperliquid.Api.Info.MaxMarketOrderNtls,
      [:user], []},
@@ -116,12 +123,18 @@ defmodule Hyperliquid.Node do
      []},
     # ---- Other single-param endpoints ----
     {:margin_table, "marginTable", Hyperliquid.Api.Info.MarginTable, [:id], []},
+    # The node rejects this one: probed against a live node on 2026-08-09 with
+    # both string and integer token values and it never deserialized. Kept so the
+    # generic info_request/2 fallback stays the only surprise, but expect an
+    # error rather than data.
     {:aligned_quote_token_info, "alignedQuoteTokenInfo",
      Hyperliquid.Api.Info.AlignedQuoteTokenInfo, [:token], []},
     {:borrow_lend_reserve_state, "borrowLendReserveState",
      Hyperliquid.Api.Info.BorrowLendReserveState, [:token], []},
     {:perp_annotation, "perpAnnotation", Hyperliquid.Api.Info.PerpAnnotation, [:coin], []},
     {:perp_dex_limits, "perpDexLimits", Hyperliquid.Api.Info.PerpDexLimits, [:dex], []},
+    {:perp_dex_status, "perpDexStatus", Hyperliquid.Api.Info.PerpDexStatus, [:dex], []},
+    {:settled_outcome, "settledOutcome", Hyperliquid.Api.Info.SettledOutcome, [:outcome], []},
     # ---- Raw (no endpoint module) ----
     # webData2 doesn't compute assetCtxs on node, no dedicated module
     {:web_data2, "webData2", nil, [:user], []}

--- a/lib/hyperliquid/transport/http.ex
+++ b/lib/hyperliquid/transport/http.ex
@@ -72,6 +72,32 @@ defmodule Hyperliquid.Transport.Http do
   end
 
   @doc """
+  Make a request to a local node's Info API.
+
+  Sends an info request to `Config.node_url()/info` instead of the public API.
+  The local info server supports a documented subset of info requests plus
+  `fileSnapshot` requests.
+
+  ## Parameters
+    - `payload`: Map with query parameters (must include `"type"` key)
+    - `opts`: Optional HTTPoison options
+
+  ## Returns
+    - `{:ok, response}` - Parsed JSON response (snake_cased)
+    - `{:error, %Error{}}` - Error with details
+
+  ## Examples
+
+      {:ok, meta} = Http.node_info_request(%{type: "meta"})
+      {:ok, state} = Http.node_info_request(%{type: "clearinghouseState", user: "0x..."})
+  """
+  @spec node_info_request(map(), request_opts()) :: response()
+  def node_info_request(payload, opts \\ []) when is_map(payload) do
+    url = "#{Config.node_url()}/info"
+    post(url, payload, opts)
+  end
+
+  @doc """
   Make a request to the Explorer API.
 
   Used for block_details, user_details, and tx_details endpoints.

--- a/lib/hyperliquid/websocket/manager.ex
+++ b/lib/hyperliquid/websocket/manager.ex
@@ -5,27 +5,42 @@ defmodule Hyperliquid.WebSocket.Manager do
   Manages multiple WebSocket connections, routes subscriptions to appropriate
   connections, and provides a registry of active subscriptions.
 
-  ## Connection Types
+  ## Connection Strategy
 
-  Subscriptions are categorized by their connection requirements:
+  All subscriptions share as few connections as possible within Hyperliquid's limits:
 
-  - `:shared` - Can share a connection with other subscriptions (e.g., allMids, trades)
-  - `:dedicated` - Needs its own connection due to response format (e.g., l2Book with params)
-  - `:user_grouped` - Must share connection with other subs for same user (e.g., userFills)
+  - **Shared socket** (`"shared"`) — all `:shared` and `:dedicated` subscriptions
+    land here. The `:dedicated` type is legacy; modules may still declare it but
+    the manager treats it identically to `:shared`.
+
+  - **First user socket** — when the first `:user_grouped` subscription is created,
+    it is placed on the shared socket. No extra connection is opened.
+
+  - **Per-user sockets** (`"user:<address>"`) — each additional unique user gets
+    its own connection so that message routing remains unambiguous (the connection
+    itself is the routing tag; user addresses are not guaranteed in WS responses).
+
+  Because the shared socket carries mixed subscription types, the manager filters
+  incoming messages by channel before dispatching to each subscription's callback.
 
   ## Usage
 
-      # Subscribe to allMids (shared connection)
+      # Subscribe to allMids (shared socket)
       {:ok, sub_id} = Manager.subscribe(Hyperliquid.Api.Subscription.AllMids, %{})
 
-      # Subscribe to l2Book (dedicated connection per variant)
+      # Subscribe to l2Book — also lands on the shared socket
       {:ok, sub_id} = Manager.subscribe(Hyperliquid.Api.Subscription.L2Book, %{
         coin: "BTC", nSigFigs: 5
       })
 
-      # Subscribe to user fills (grouped by user)
+      # First user subscription — shares the existing shared socket
       {:ok, sub_id} = Manager.subscribe(Hyperliquid.Api.Subscription.UserFills, %{
         user: "0x1234..."
+      })
+
+      # Second user — gets its own socket
+      {:ok, sub_id} = Manager.subscribe(Hyperliquid.Api.Subscription.UserFills, %{
+        user: "0xabcd..."
       })
 
       # Unsubscribe
@@ -41,8 +56,8 @@ defmodule Hyperliquid.WebSocket.Manager do
   The Manager maintains:
 
   1. A registry of active subscriptions (ETS table)
-  2. A mapping of subscription keys to connection PIDs
-  3. Connection metadata (shared vs dedicated, user grouping)
+  2. A mapping of connection keys to connection PIDs
+  3. Connection metadata and per-subscription metrics
   """
 
   use GenServer
@@ -208,7 +223,9 @@ defmodule Hyperliquid.WebSocket.Manager do
       # Map of subscription_id => subscription
       subscriptions: %{},
       # Counter for generating unique IDs
-      counter: 0
+      counter: 0,
+      # Millisecond timestamps of recent connection creations (for rate limiting)
+      connection_timestamps: []
     }
 
     {:ok, state}
@@ -241,51 +258,66 @@ defmodule Hyperliquid.WebSocket.Manager do
         end
 
       :not_found ->
-        # No existing subscription, create a new one
-        sub_id = generate_subscription_id(state.counter)
+        # Enforce Hyperliquid rate limits before creating a new subscription
+        with :ok <- check_subscription_limit(state),
+             :ok <- check_user_limit(state, connection_type, params, ws_url) do
+          # No existing subscription, create a new one
+          sub_id = generate_subscription_id(state.counter)
 
-        # Build the subscription request
-        case module.build_request(coerced_params) do
-          {:ok, request} ->
-            # Determine which connection to use
-            {connection_key, connection_pid, state} =
-              get_or_create_connection(connection_type, subscription_key, params, ws_url, state)
+          # Build the subscription request
+          case module.build_request(coerced_params) do
+            {:ok, request} ->
+              # Determine which connection to use (may enforce connection limits)
+              case get_or_create_connection(
+                     connection_type,
+                     subscription_key,
+                     params,
+                     ws_url,
+                     state
+                   ) do
+                {:ok, connection_key, connection_pid, state} ->
+                  # Create subscription record
+                  subscription = %Subscription{
+                    id: sub_id,
+                    module: module,
+                    params: params,
+                    key: connection_key,
+                    connection_type: connection_type,
+                    connection_pid: connection_pid,
+                    callback: callback,
+                    subscribed_at: DateTime.utc_now()
+                  }
 
-            # Create subscription record
-            subscription = %Subscription{
-              id: sub_id,
-              module: module,
-              params: params,
-              key: connection_key,
-              connection_type: connection_type,
-              connection_pid: connection_pid,
-              callback: callback,
-              subscribed_at: DateTime.utc_now()
-            }
+                  # Store in ETS and state
+                  :ets.insert(:ws_subscriptions, {sub_id, subscription})
+                  subscriptions = Map.put(state.subscriptions, sub_id, subscription)
 
-            # Store in ETS and state
-            :ets.insert(:ws_subscriptions, {sub_id, subscription})
-            subscriptions = Map.put(state.subscriptions, sub_id, subscription)
+                  # Send subscription to connection
+                  send_subscription(connection_pid, request, sub_id)
 
-            # Send subscription to connection
-            send_subscription(connection_pid, request, sub_id)
+                  new_state = %{state | subscriptions: subscriptions, counter: state.counter + 1}
 
-            new_state = %{state | subscriptions: subscriptions, counter: state.counter + 1}
+                  :telemetry.execute(
+                    [:hyperliquid, :ws, :subscribe],
+                    %{count: 1},
+                    %{module: module, key: subscription_key}
+                  )
 
-            :telemetry.execute(
-              [:hyperliquid, :ws, :subscribe],
-              %{count: 1},
-              %{module: module, key: subscription_key}
-            )
+                  Logger.info(
+                    "Subscribed #{inspect(module)} with key #{subscription_key}, id: #{sub_id}"
+                  )
 
-            Logger.info(
-              "Subscribed #{inspect(module)} with key #{subscription_key}, id: #{sub_id}"
-            )
+                  {:reply, {:ok, sub_id}, new_state}
 
-            {:reply, {:ok, sub_id}, new_state}
+                {:error, reason} ->
+                  {:reply, {:error, reason}, state}
+              end
 
-          {:error, reason} ->
-            {:reply, {:error, reason}, state}
+            {:error, reason} ->
+              {:reply, {:error, reason}, state}
+          end
+        else
+          {:error, reason} -> {:reply, {:error, reason}, state}
         end
     end
   end
@@ -462,24 +494,19 @@ defmodule Hyperliquid.WebSocket.Manager do
   def handle_info({:ws_message, connection_pid, message}, state) do
     now = DateTime.utc_now()
 
-    # Update metrics and route message to appropriate subscription callbacks
+    # Route message to matching subscription callbacks.
+    # The shared socket carries mixed subscription types (shared, dedicated, and the first user),
+    # so we filter by channel to avoid cross-dispatching (e.g. an allMids message should not
+    # trigger an l2Book callback). Per-user connections only carry that user's subscriptions,
+    # so filtering there is a no-op but still correct.
     subscriptions =
       state.subscriptions
       |> Enum.map(fn {id, sub} ->
-        if sub.connection_pid == connection_pid do
-          # Update metrics
+        if sub.connection_pid == connection_pid && message_matches_subscription?(message, sub) do
           updated_sub = update_subscription_metrics(sub, now)
-
-          # Store in ETS
           :ets.insert(:ws_subscriptions, {id, updated_sub})
-
-          # Store to configured backends (async)
-          # Pass subscription params for context (e.g., user address for user_grouped)
           maybe_store_event(sub.module, sub.params, message)
-
-          # Call callback if present
           if sub.callback, do: sub.callback.(message)
-
           {id, updated_sub}
         else
           {id, sub}
@@ -683,7 +710,8 @@ defmodule Hyperliquid.WebSocket.Manager do
     "sub_#{timestamp}_#{counter}"
   end
 
-  defp get_or_create_connection(connection_type, subscription_key, params, ws_url, state) do
+  # Returns {:ok, connection_key, pid, state} | {:error, reason}
+  defp get_or_create_connection(connection_type, _subscription_key, params, ws_url, state) do
     # Include URL in connection key for different WS endpoints
     url_suffix =
       if ws_url != Hyperliquid.Config.ws_url(), do: ":#{URI.parse(ws_url).host}", else: ""
@@ -691,29 +719,182 @@ defmodule Hyperliquid.WebSocket.Manager do
     connection_key =
       case connection_type do
         :shared -> "shared#{url_suffix}"
-        :dedicated -> "#{subscription_key}#{url_suffix}"
-        :user_grouped -> "user:#{params[:user] || params["user"]}#{url_suffix}"
+        # :dedicated is legacy — fold onto the shared socket
+        :dedicated -> "shared#{url_suffix}"
+        :user_grouped -> user_connection_key(params, state, url_suffix)
       end
 
     case Map.get(state.connections, connection_key) do
       nil ->
-        # Create new connection
-        {:ok, pid} = start_connection(connection_key, ws_url)
-        Process.monitor(pid)
-        connections = Map.put(state.connections, connection_key, pid)
-        {connection_key, pid, %{state | connections: connections}}
+        # Would create a new connection — enforce connection count and rate limits
+        with :ok <- check_connection_count_limit(state),
+             :ok <- check_connection_rate_limit(state) do
+          {:ok, pid} = start_connection(connection_key, ws_url)
+          Process.monitor(pid)
+          connections = Map.put(state.connections, connection_key, pid)
+          state = track_connection_timestamp(%{state | connections: connections})
+          {:ok, connection_key, pid, state}
+        end
 
       pid when is_pid(pid) ->
         if Process.alive?(pid) do
-          {connection_key, pid, state}
+          {:ok, connection_key, pid, state}
         else
-          # Connection died, create new one
-          {:ok, new_pid} = start_connection(connection_key, ws_url)
-          Process.monitor(new_pid)
-          connections = Map.put(state.connections, connection_key, new_pid)
-          {connection_key, new_pid, %{state | connections: connections}}
+          # Connection died — check rate limit before replacing (count stays the same)
+          with :ok <- check_connection_rate_limit(state) do
+            {:ok, new_pid} = start_connection(connection_key, ws_url)
+            Process.monitor(new_pid)
+            connections = Map.put(state.connections, connection_key, new_pid)
+            state = track_connection_timestamp(%{state | connections: connections})
+            {:ok, connection_key, new_pid, state}
+          end
         end
     end
+  end
+
+  # Returns the connection key for a user_grouped subscription.
+  # The first unique user shares the existing shared socket (no new connection needed).
+  # Each subsequent unique user gets its own "user:#{address}" connection so that
+  # message routing remains unambiguous (user address is not guaranteed in WS responses).
+  defp user_connection_key(params, state, url_suffix) do
+    address = params[:user] || params["user"]
+    shared_key = "shared#{url_suffix}"
+    user_key = "user:#{address}#{url_suffix}"
+
+    cond do
+      # User already has a dedicated connection
+      Map.has_key?(state.connections, user_key) ->
+        user_key
+
+      # User is already on the shared socket
+      address in users_on_connection(state.subscriptions, shared_key) ->
+        shared_key
+
+      # First user — goes on the shared socket
+      users_on_connection(state.subscriptions, shared_key) == [] ->
+        shared_key
+
+      # Additional user — gets its own connection
+      true ->
+        user_key
+    end
+  end
+
+  # Returns the list of unique user addresses whose user_grouped subscriptions
+  # are routed through the given connection key.
+  defp users_on_connection(subscriptions, connection_key) do
+    subscriptions
+    |> Map.values()
+    |> Enum.filter(fn sub ->
+      sub.connection_type == :user_grouped && sub.key == connection_key
+    end)
+    |> Enum.map(fn sub -> sub.params[:user] || sub.params["user"] end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  # ===================== Rate Limit Helpers =====================
+
+  # Max 1000 simultaneous subscriptions (Hyperliquid limit)
+  defp check_subscription_limit(state) do
+    if map_size(state.subscriptions) >= Hyperliquid.Config.ws_max_subscriptions() do
+      Logger.warning("WebSocket subscription limit reached (#{Hyperliquid.Config.ws_max_subscriptions()})")
+      {:error, :subscription_limit_exceeded}
+    else
+      :ok
+    end
+  end
+
+  # Max 10 unique users across user-specific subscriptions (Hyperliquid limit).
+  # The first user shares the shared socket (no new connection consumed).
+  # Each subsequent unique user needs its own connection, so we also check the
+  # connection budget for those cases.
+  defp check_user_limit(state, :user_grouped, params, ws_url) do
+    new_user = params[:user] || params["user"]
+    existing_users = unique_ws_users(state.subscriptions)
+
+    if new_user not in existing_users do
+      if length(existing_users) >= Hyperliquid.Config.ws_max_users() do
+        Logger.warning(
+          "WebSocket user limit reached (#{Hyperliquid.Config.ws_max_users()} unique users)"
+        )
+
+        {:error, :user_limit_exceeded}
+      else
+        # Check whether this user would require a new connection.
+        # The first user lands on the shared socket; additional users each need one.
+        url_suffix =
+          if ws_url != Hyperliquid.Config.ws_url(), do: ":#{URI.parse(ws_url).host}", else: ""
+
+        shared_key = "shared#{url_suffix}"
+        users_on_shared = users_on_connection(state.subscriptions, shared_key)
+        needs_new_connection = users_on_shared != []
+
+        if needs_new_connection &&
+             map_size(state.connections) >= Hyperliquid.Config.ws_max_connections() do
+          Logger.warning(
+            "WebSocket connection budget exhausted — cannot add new user (#{map_size(state.connections)}/#{Hyperliquid.Config.ws_max_connections()} connections in use)"
+          )
+
+          {:error, :connection_limit_exceeded}
+        else
+          :ok
+        end
+      end
+    else
+      :ok
+    end
+  end
+
+  defp check_user_limit(_state, _connection_type, _params, _ws_url), do: :ok
+
+  # Max 10 simultaneous connections (Hyperliquid limit)
+  defp check_connection_count_limit(state) do
+    if map_size(state.connections) >= Hyperliquid.Config.ws_max_connections() do
+      Logger.warning("WebSocket connection limit reached (#{Hyperliquid.Config.ws_max_connections()})")
+      {:error, :connection_limit_exceeded}
+    else
+      :ok
+    end
+  end
+
+  # Max 30 new connections per minute (Hyperliquid limit)
+  defp check_connection_rate_limit(state) do
+    now = System.system_time(:millisecond)
+    one_minute_ago = now - 60_000
+    recent_count = Enum.count(state.connection_timestamps, &(&1 > one_minute_ago))
+
+    if recent_count >= Hyperliquid.Config.ws_max_connections_per_minute() do
+      Logger.warning(
+        "WebSocket connection rate limit reached (#{Hyperliquid.Config.ws_max_connections_per_minute()} new connections/min)"
+      )
+
+      {:error, :connection_rate_exceeded}
+    else
+      :ok
+    end
+  end
+
+  # Record a new connection timestamp and prune entries older than 1 minute
+  defp track_connection_timestamp(state) do
+    now = System.system_time(:millisecond)
+    one_minute_ago = now - 60_000
+
+    pruned =
+      [now | state.connection_timestamps]
+      |> Enum.filter(&(&1 > one_minute_ago))
+
+    %{state | connection_timestamps: pruned}
+  end
+
+  # Returns the list of unique user addresses currently tracked in user_grouped subscriptions
+  defp unique_ws_users(subscriptions) do
+    subscriptions
+    |> Map.values()
+    |> Enum.filter(&(&1.connection_type == :user_grouped))
+    |> Enum.map(fn sub -> sub.params[:user] || sub.params["user"] end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
   end
 
   defp start_connection(connection_key, ws_url) do
@@ -870,6 +1051,16 @@ defmodule Hyperliquid.WebSocket.Manager do
   defp round_if_float(value) when is_float(value), do: Float.round(value, 2)
   defp round_if_float(value) when is_integer(value), do: value * 1.0
   defp round_if_float(value), do: value
+
+  # Returns true if the WS message should be dispatched to the given subscription.
+  # We match on message["channel"] against the subscription module's request_type.
+  # Messages without a channel key (e.g., pong) are delivered to all subs on the connection.
+  defp message_matches_subscription?(message, sub) do
+    case message["channel"] do
+      nil -> true
+      channel -> channel == get_request_type(sub.module)
+    end
+  end
 
   # ===================== Storage Integration =====================
 

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -1,0 +1,358 @@
+defmodule Hyperliquid.NodeTest do
+  use ExUnit.Case, async: false
+
+  alias Hyperliquid.Node
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:hyperliquid, :node_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.delete_env(:hyperliquid, :node_url)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  # ===================== Documented Endpoints =====================
+
+  describe "no-param endpoints" do
+    test "meta/0 sends correct payload and parses response", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "meta"
+
+        resp = %{"universe" => [], "collateralToken" => 0}
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, result} = Node.meta()
+      # parse_response returns a struct
+      assert is_struct(result)
+    end
+
+    test "exchange_status/0 sends correct payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "exchangeStatus"
+
+        resp = %{"time" => 1_700_000_000_000, "specialStatuses" => %{}}
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.exchange_status()
+    end
+
+    test "spot_meta/0 sends correct payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "spotMeta"
+
+        resp = %{"universe" => [], "tokens" => []}
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.spot_meta()
+    end
+  end
+
+  describe "user-param endpoints" do
+    test "clearinghouse_state/1 sends user in payload", %{bypass: bypass} do
+      user = "0xabcdef1234567890abcdef1234567890abcdef12"
+
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "clearinghouseState"
+        assert payload["user"] == user
+
+        resp = %{
+          "marginSummary" => %{
+            "accountValue" => "1000.0",
+            "totalNtlPos" => "0.0",
+            "totalRawUsd" => "1000.0",
+            "totalMarginUsed" => "0.0"
+          },
+          "crossMarginSummary" => %{
+            "accountValue" => "1000.0",
+            "totalNtlPos" => "0.0",
+            "totalRawUsd" => "1000.0",
+            "totalMarginUsed" => "0.0"
+          },
+          "crossMaintenanceMarginUsed" => "0.0",
+          "withdrawable" => "1000.0",
+          "assetPositions" => [],
+          "time" => 1_700_000_000_000
+        }
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.clearinghouse_state(user)
+    end
+
+    test "open_orders/1 sends user in payload", %{bypass: bypass} do
+      user = "0xabcdef1234567890abcdef1234567890abcdef12"
+
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "openOrders"
+        assert payload["user"] == user
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!([]))
+      end)
+
+      assert {:ok, _result} = Node.open_orders(user)
+    end
+  end
+
+  describe "user+coin endpoints" do
+    test "active_asset_data/2 sends user and coin in payload", %{bypass: bypass} do
+      user = "0xabcdef1234567890abcdef1234567890abcdef12"
+      coin = "BTC"
+
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "activeAssetData"
+        assert payload["user"] == user
+        assert payload["coin"] == coin
+
+        resp = %{
+          "coin" => "BTC",
+          "leverage" => %{"type" => "cross", "value" => 5},
+          "maxTradeSzs" => ["1.0", "0.5"],
+          "availableToTrade" => ["100.0", "50.0"],
+          "markPx" => "45000.0"
+        }
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.active_asset_data(user, coin)
+    end
+  end
+
+  describe "web_data2 (nil endpoint module)" do
+    test "web_data2/1 returns raw snake_cased map", %{bypass: bypass} do
+      user = "0xabcdef1234567890abcdef1234567890abcdef12"
+
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "webData2"
+        assert payload["user"] == user
+
+        resp = %{"clearinghouseState" => %{}, "openOrders" => []}
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, result} = Node.web_data2(user)
+      # nil endpoint module returns raw snake_cased map
+      assert is_map(result)
+      assert Map.has_key?(result, "clearinghouse_state")
+    end
+  end
+
+  # ===================== Generic Fallback =====================
+
+  describe "info_request/2" do
+    test "sends arbitrary payload to node /info", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "someUndocumented"
+        assert payload["customParam"] == "value"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"result" => "ok"}))
+      end)
+
+      assert {:ok, %{"result" => "ok"}} =
+               Node.info_request(%{type: "someUndocumented", customParam: "value"})
+    end
+  end
+
+  # ===================== File Snapshots =====================
+
+  describe "file_snapshot/3" do
+    test "builds correct fileSnapshot payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "fileSnapshot"
+        assert payload["request"] == %{"type" => "referrerStates"}
+        assert payload["outPath"] == "/tmp/out.json"
+        assert payload["includeHeightInOutput"] == false
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!("ok"))
+      end)
+
+      assert {:ok, "ok"} = Node.file_snapshot(%{type: "referrerStates"}, "/tmp/out.json")
+    end
+
+    test "passes include_height option", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["includeHeightInOutput"] == true
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!("ok"))
+      end)
+
+      assert {:ok, _} =
+               Node.file_snapshot(%{type: "referrerStates"}, "/tmp/out.json", include_height: true)
+    end
+  end
+
+  describe "referrer_states_snapshot/2" do
+    test "delegates to file_snapshot with referrerStates request", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "fileSnapshot"
+        assert payload["request"] == %{"type" => "referrerStates"}
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!("ok"))
+      end)
+
+      assert {:ok, _} = Node.referrer_states_snapshot("/tmp/referrer.json")
+    end
+  end
+
+  describe "l4_snapshots/2" do
+    test "builds correct l4Snapshots request with defaults", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "fileSnapshot"
+        assert payload["request"]["type"] == "l4Snapshots"
+        assert payload["request"]["includeUsers"] == true
+        assert payload["request"]["includeTriggerOrders"] == true
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!("ok"))
+      end)
+
+      assert {:ok, _} = Node.l4_snapshots("/tmp/l4.json")
+    end
+
+    test "respects include_users and include_trigger_orders options", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["request"]["includeUsers"] == false
+        assert payload["request"]["includeTriggerOrders"] == false
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!("ok"))
+      end)
+
+      assert {:ok, _} =
+               Node.l4_snapshots("/tmp/l4.json",
+                 include_users: false,
+                 include_trigger_orders: false
+               )
+    end
+  end
+
+  # ===================== Ping =====================
+
+  describe "ping/0" do
+    test "sends exchangeStatus request to node", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "exchangeStatus"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"time" => 1_700_000_000_000}))
+      end)
+
+      assert {:ok, _} = Node.ping()
+    end
+
+    test "returns error when node is unreachable" do
+      # Point to a port nothing is listening on
+      Application.put_env(:hyperliquid, :node_url, "http://localhost:1")
+      assert {:error, _} = Node.ping()
+    end
+  end
+
+  # ===================== Error Handling =====================
+
+  describe "error handling" do
+    test "returns error on non-200 response", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(500, Jason.encode!(%{"error" => "internal"}))
+      end)
+
+      assert {:error, _} = Node.meta()
+    end
+  end
+
+  # ===================== Config =====================
+
+  describe "config" do
+    test "node_url defaults to localhost:3001" do
+      Application.delete_env(:hyperliquid, :node_url)
+      assert Hyperliquid.Config.node_url() == "http://localhost:3001"
+    end
+
+    test "node_rpc_enabled? defaults to false" do
+      Application.delete_env(:hyperliquid, :enable_node_rpc)
+      refute Hyperliquid.Config.node_rpc_enabled?()
+    end
+
+    test "node_rpc_enabled? returns true when configured" do
+      Application.put_env(:hyperliquid, :enable_node_rpc, true)
+      assert Hyperliquid.Config.node_rpc_enabled?()
+      Application.delete_env(:hyperliquid, :enable_node_rpc)
+    end
+
+    test "node_info_enabled? defaults to false" do
+      Application.delete_env(:hyperliquid, :enable_node_info)
+      refute Hyperliquid.Config.node_info_enabled?()
+    end
+
+    test "node_info_enabled? returns true when configured" do
+      Application.put_env(:hyperliquid, :enable_node_info, true)
+      assert Hyperliquid.Config.node_info_enabled?()
+      Application.delete_env(:hyperliquid, :enable_node_info)
+    end
+  end
+end

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -66,6 +66,62 @@ defmodule Hyperliquid.NodeTest do
 
       assert {:ok, _result} = Node.spot_meta()
     end
+
+    test "all_perp_metas/0 sends correct payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "allPerpMetas"
+
+        resp = [%{"universe" => [], "marginTables" => [], "collateralToken" => 0}]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.all_perp_metas()
+    end
+
+    test "all_borrow_lend_reserve_states/0 sends correct payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "allBorrowLendReserveStates"
+
+        resp = [[0, %{"borrowYearlyRate" => "0.05", "supplyYearlyRate" => "0.01",
+                       "balance" => "1000.0", "utilization" => "0.5",
+                       "oraclePx" => "1.0", "ltv" => "0.9"}]]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.all_borrow_lend_reserve_states()
+    end
+
+    test "spot_pair_deploy_auction_status/0 sends correct payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "spotPairDeployAuctionStatus"
+
+        resp = %{
+          "startTimeSeconds" => 1_700_000_000,
+          "durationSeconds" => 111_600,
+          "startGas" => "500.0",
+          "currentGas" => "500.0",
+          "endGas" => nil
+        }
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.spot_pair_deploy_auction_status()
+    end
   end
 
   describe "user-param endpoints" do
@@ -121,6 +177,40 @@ defmodule Hyperliquid.NodeTest do
 
       assert {:ok, _result} = Node.open_orders(user)
     end
+
+    test "sub_accounts2/1 sends user in payload", %{bypass: bypass} do
+      user = "0xabcdef1234567890abcdef1234567890abcdef12"
+
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "subAccounts2"
+        assert payload["user"] == user
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!([]))
+      end)
+
+      assert {:ok, _result} = Node.sub_accounts2(user)
+    end
+
+    test "user_dex_abstraction/1 sends user in payload", %{bypass: bypass} do
+      user = "0xabcdef1234567890abcdef1234567890abcdef12"
+
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "userDexAbstraction"
+        assert payload["user"] == user
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(nil))
+      end)
+
+      assert {:ok, _result} = Node.user_dex_abstraction(user)
+    end
   end
 
   describe "user+coin endpoints" do
@@ -149,6 +239,58 @@ defmodule Hyperliquid.NodeTest do
       end)
 
       assert {:ok, _result} = Node.active_asset_data(user, coin)
+    end
+  end
+
+  describe "single-param endpoints" do
+    test "margin_table/1 sends id in payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "marginTable"
+        assert payload["id"] == 56
+
+        resp = %{
+          "description" => "tiered 40x",
+          "marginTiers" => [%{"lowerBound" => "0.0", "maxLeverage" => 40}]
+        }
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(resp))
+      end)
+
+      assert {:ok, _result} = Node.margin_table(56)
+    end
+
+    test "aligned_quote_token_info/1 sends token in payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "alignedQuoteTokenInfo"
+        assert payload["token"] == 0
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(nil))
+      end)
+
+      assert {:ok, nil} = Node.aligned_quote_token_info(0)
+    end
+
+    test "perp_dex_limits/1 sends dex in payload", %{bypass: bypass} do
+      Bypass.expect(bypass, "POST", "/info", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["type"] == "perpDexLimits"
+        assert payload["dex"] == "hyperliquid"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(nil))
+      end)
+
+      assert {:ok, _result} = Node.perp_dex_limits("hyperliquid")
     end
   end
 


### PR DESCRIPTION
Adds `Hyperliquid.Node` for querying a self-hosted Hyperliquid node directly, plus WebSocket connection rate limiting. Rebased onto current `main`, so it sits on top of the signing fixes, endpoint parity and outcome assets.

## Local node client

When a node runs with `--serve-info` and/or `--serve-eth-rpc`, both surfaces are served on port 3001 — `/info` and `/evm`. `Hyperliquid.Node` gives low-latency access to both without public API rate limits.

Convenience functions are generated from a table of verified endpoints, reusing the existing `Api.Info` modules so responses come back as parsed structs rather than raw maps:

```elixir
{:ok, meta}   = Node.meta()
{:ok, state}  = Node.clearinghouse_state("0x...", dex: "some_dex")
{:ok, table}  = Node.margin_table(56)

# Generic fallback for anything not in the table
{:ok, data} = Node.info_request(%{type: "someEndpoint", user: "0x..."})
```

Info and RPC are independently switchable (`enable_node_info`, `enable_node_rpc`), so you can point at a node for reads while leaving RPC off.

## Verified against a live node

Rather than trusting the documented list, all 78 info request types were probed against a running node on 2026-08-09. **It serves 48.** The client now exposes 47 of them — every one except `alignedQuoteTokenInfo`, which the node rejects.

The final commit adds the six the client was missing:

```
gossipPriorityAuctionStatus   perpConciseAnnotations
outcomeMeta                   outcomeTemplates
perpDexStatus                 settledOutcome
```

Four are endpoints `main` gained in v0.3.0, so the node could serve them before the client could ask.

**Two corrections to the support table this produced:**

- `perpDexStatus` was documented as not supported. The node serves it.
- `alignedQuoteTokenInfo` was documented as supported. The node rejects it, with both string and integer token values.

**A probing caveat worth knowing:** the node returns the same `Failed to deserialize the JSON body into the target type` for an unknown request type *and* a malformed one. `borrowLendReserveState` needs an **integer** token — a string looks exactly like an unsupported endpoint. My first pass produced false negatives because of this, so any type absent from the list may simply need a different request shape rather than being unsupported.

The endpoints the node does not serve are market data and user history — `allMids`, `l2Book`, `candleSnapshot`, `userFills`, `portfolio`. That split is coherent: the node holds state, not indexed history or aggregated books. Those keep falling back to the public API.

## EVM RPC

`enable_node_rpc: true` registers a `:node` named RPC at `node_url/evm`, so the whole existing typed RPC surface routes to the node, not just a raw call helper. Verified end to end:

```
Node.rpc_call("eth_blockNumber")       → {:ok, "0x28c3813"}
Node.rpc_call("eth_chainId")           → {:ok, "0x3e7"}   (999, HyperEVM)
Rpc.Eth.block_number(rpc_name: :node)  → {:ok, "0x28c3813"}
Node.ping()                            → {:ok, %{"time" => ...}}
```

## File snapshots

`fileSnapshot` requests write large datasets to a file on the node's filesystem instead of returning them over HTTP, with helpers for `referrerStates` and `l4Snapshots`. Worth knowing before you call it: a single `referrerStates` snapshot wrote **593 MB** during testing.

## WebSocket rate limiting

`WebSocket.Manager` now enforces Hyperliquid's limits before opening a connection — both the connection count and a new-connections-per-minute window — including on the replace path when a connection dies, where the count is unchanged but the rate still applies.

## Documentation

README gains a `Running the node` section: the flags, curl checks for both surfaces with real expected output, and a note to **tunnel the port rather than expose it** — the info server binds `0.0.0.0` and is unauthenticated.

```bash
ssh -N -L 3001:localhost:3001 your-node-host
```

## Testing

318 tests, 10 failures — the same pre-existing set on this machine (4 RPC, 4 debug, 2 info), with 15 Postgres tests excluded absent a database. `test/node_test.exs` adds 500 lines covering payload construction, optional-param handling and the generated function surface.

One conflict during the rebase: this branch had numbered its work `## 0.2.3` while `main` shipped 0.3.1. It is filed as `## Unreleased` above 0.3.1 rather than inserted as a lower version below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)